### PR TITLE
Add semantic token type mapping functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.2.0
+
+Supported Tree-sitter ABI version: 14
+
+### Features
+
+- Add support for relative paths
+
 ## 0.1.0
 
 Supported Tree-sitter ABI version: 14

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-vscode",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-vscode",
-      "version": "0.0.1",
+      "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/vsce": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "commands": [
       {
         "command": "tree-sitter-vscode.reload",
-        "title": "Tree Sitter: Reload"
+        "title": "tree-sitter-vscode: Reload"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AlecGhost"
   },
   "publisher": "AlecGhost",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/AlecGhost/tree-sitter-vscode"
@@ -28,9 +28,14 @@
         "title": "tree-sitter-vscode config",
         "properties": {
           "tree-sitter-vscode.languageConfigs": {
-            "description": "A list of objects with the keys \"lang\", \"parser\" and \"highlights\". Optionally, \"injections\" and \"injectionOnly\" can be added.",
+            "description": "A list of objects with the keys \"lang\", \"parser\", and \"highlights\". Optionally \"injections\", \"injectionOnly\", and \"semanticTokenTypeMappings\" can be added.",
             "type": "array",
             "default": []
+          },
+          "tree-sitter-vscode.debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable debug logging"
           }
         }
       }
@@ -38,7 +43,7 @@
     "commands": [
       {
         "command": "tree-sitter-vscode.reload",
-        "title": "tree-sitter-vscode: Reload"
+        "title": "Tree Sitter: Reload"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -31,11 +31,6 @@
             "description": "A list of objects with the keys \"lang\", \"parser\", and \"highlights\". Optionally \"injections\", \"injectionOnly\", and \"semanticTokenTypeMappings\" can be added.",
             "type": "array",
             "default": []
-          },
-          "tree-sitter-vscode.debug": {
-            "type": "boolean",
-            "default": false,
-            "description": "Enable debug logging"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
             "description": "A list of objects with the keys \"lang\", \"parser\", and \"highlights\". Optionally \"injections\", \"injectionOnly\", and \"semanticTokenTypeMappings\" can be added.",
             "type": "array",
             "default": []
+          },
+          "tree-sitter-vscode.debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable debug logging"
           }
         }
       }
@@ -38,7 +43,7 @@
     "commands": [
       {
         "command": "tree-sitter-vscode.reload",
-        "title": "tree-sitter-vscode: Reload"
+        "title": "Tree Sitter: Reload"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,116 +6,42 @@ import Parser from 'web-tree-sitter';
 // VSCode default token types and modifiers from:
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 const TOKEN_TYPES = [
-  "namespace",
-  "class",
-  "enum",
-  "interface",
-  "struct",
-  "typeParameter",
-  "type",
-  "parameter",
-  "variable",
-  "property",
-  "enumMember",
-  "decorator",
-  "event",
-  "function",
-  "method",
-  "macro",
-  "label",
-  "comment",
-  "string",
-  "keyword",
-  "number",
-  "regexp",
-  "operator",
+  'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
+  'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
+  'number', 'regexp', 'operator',
 ];
 const TOKEN_MODIFIERS = [
-  "declaration",
-  "definition",
-  "readonly",
-  "static",
-  "deprecated",
-  "abstract",
-  "async",
-  "modification",
-  "documentation",
-  "defaultLibrary",
+  'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
+  'documentation', 'defaultLibrary',
 ];
 const LEGEND = new vscode.SemanticTokensLegend(TOKEN_TYPES, TOKEN_MODIFIERS);
 
-type SemanticTokenTypeMapping = {
-  targetTokenType: string;
-  targetTokenModifiers?: string[]; // Changed from string to string[]
-};
-type Config = {
-  lang: string;
-  parser: string;
-  highlights: string;
-  injections?: string;
-  injectionOnly: boolean;
-  semanticTokenTypeMappings?: {
-    [sourceSemanticTokenType: string]: SemanticTokenTypeMapping;
-  };
-};
-type Language = {
-  parser: Parser;
-  highlightQuery: Parser.Query;
-  injectionQuery?: Parser.Query;
-  semanticTokenTypeMappings?: {
-    [sourceSemanticTokenType: string]: SemanticTokenTypeMapping;
-  };
-};
-type Token = { range: vscode.Range; type: string; modifiers: string[] };
-type Injection = { range: vscode.Range; tokens: Token[] };
-
-function log(messageOrCallback: string | (() => string), data?: any) {
-  // Only log in debug mode
-  const config = vscode.workspace.getConfiguration("tree-sitter-vscode");
-  const isDebugMode = config.get("debug", false);
-
-  if (isDebugMode) {
-    const timestamp = new Date().toISOString();
-    const message =
-      typeof messageOrCallback === "function"
-        ? messageOrCallback()
-        : messageOrCallback;
-    OUTPUT_CHANNEL.appendLine(`[${timestamp}] ${message}`);
-    if (data) {
-      OUTPUT_CHANNEL.appendLine(JSON.stringify(data, null, 2));
-    }
-  }
-}
+type SemanticTokenTypeMapping = { targetTokenType: string, targetTokenModifiers?: string[] };
+type Config = { lang: string, parser: string, highlights: string, injections?: string, injectionOnly: boolean, semanticTokenTypeMappings?: { [sourceSemanticTokenType: string]: SemanticTokenTypeMapping } };
+type Language = { parser: Parser, highlightQuery: Parser.Query, injectionQuery?: Parser.Query, semanticTokenTypeMappings?: { [sourceSemanticTokenType: string]: SemanticTokenTypeMapping }; };
+type Token = { range: vscode.Range, type: string, modifiers: string[] };
+type Injection = { range: vscode.Range, tokens: Token[] };
 
 /**
  * Called once on extension initialization and again if the reload command is triggered.
  * It reads the configuration and registers the semantic tokens provider.
  */
 export function activate(context: vscode.ExtensionContext) {
-  log("Extension activated");
   // setup the semantic tokens provider
-  const rawConfigs = vscode.workspace
-    .getConfiguration("tree-sitter-vscode")
-    .get("languageConfigs");
+  const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
   const configs = parseConfigs(rawConfigs);
-  log(() => {
-    return `Configured languages: ${configs.map((c) => c.lang).join(", ")}`;
-  });
   const languageMap = configs
-    .filter((config) => !config.injectionOnly)
-    .map((config) => {
-      return { language: config.lang };
-    });
+    .filter(config => !config.injectionOnly)
+    .map(config => { return { language: config.lang }; });
   const provider = vscode.languages.registerDocumentSemanticTokensProvider(
     languageMap,
     new SemanticTokensProvider(configs),
-    LEGEND
+    LEGEND,
   );
   context.subscriptions.push(provider);
 
   // setup the reload command
-  const reload = vscode.commands.registerCommand(
-    "tree-sitter-vscode.reload",
+  const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
     () => {
       // dispose of the old providers and clear the list of subscriptions
       reload.dispose();
@@ -123,8 +49,7 @@ export function activate(context: vscode.ExtensionContext) {
       context.subscriptions.length = 0;
       // reinitialize the extension
       activate(context);
-    }
-  );
+    });
   context.subscriptions.push(reload);
 }
 
@@ -134,60 +59,61 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {}
 
 function parseConfigs(configs: any): Config[] {
-	if (!Array.isArray(configs)) {
-		throw new TypeError("Expected a list.");
-	}
-	return configs.map(config => {
-		const lang = config["lang"];
-		const parser = config["parser"];
-		const highlights = config["highlights"];
-		const injections = config["injections"];
-		let injectionOnly = config["injectionOnly"];
-		if (typeof lang !== "string") {
-			throw new TypeError("Expected `lang` to be a string.");
-		}
-		if (typeof parser !== "string") {
-			throw new TypeError("Expected `parser` to be a string.");
-		}
-		if (typeof highlights !== "string") {
-			throw new TypeError("Expected `highlights` to be a string.");
-		}
-		if (injections !== undefined && typeof injections !== "string") {
-			throw new TypeError("Expected `injections` to be a string.");
-		}
-		if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
-			throw new TypeError("Expected `injectionOnly` to be a boolean.");
-		}
-		if (injectionOnly === undefined) {
-			injectionOnly = false;
-		}
-		return { lang, parser, highlights, injections, injectionOnly };
-	}).map(config => {
-		const parser = toAbsolutePath(config.parser);
-		const highlights = toAbsolutePath(config.highlights);
-		const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
-		return { ...config, parser, highlights, injections };
-	});
+  if (!Array.isArray(configs)) {
+    throw new TypeError("Expected a list.");
+  }
+  return configs.map(config => {
+    const lang = config["lang"];
+    const parser = config["parser"];
+    const highlights = config["highlights"];
+    const injections = config["injections"];
+    let injectionOnly = config["injectionOnly"];
+    const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
+    if (typeof lang !== "string") {
+      throw new TypeError("Expected `lang` to be a string.");
+    }
+    if (typeof parser !== "string") {
+      throw new TypeError("Expected `parser` to be a string.");
+    }
+    if (typeof highlights !== "string") {
+      throw new TypeError("Expected `highlights` to be a string.");
+    }
+    if (injections !== undefined && typeof injections !== "string") {
+      throw new TypeError("Expected `injections` to be a string.");
+    }
+    if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
+      throw new TypeError("Expected `injectionOnly` to be a boolean.");
+    }
+    if (semanticTokenTypeMappings !== undefined && (typeof semanticTokenTypeMappings !== "object" || semanticTokenTypeMappings === null)) {
+      throw new TypeError("Expected `semanticTokenTypeMappings` to be an object.");
+    }
+    if (injectionOnly === undefined) {
+      injectionOnly = false;
+    }
+    return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
+  }).map(config => {
+    const parser = toAbsolutePath(config.parser);
+    const highlights = toAbsolutePath(config.highlights);
+    const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
+    return { ...config, parser, highlights, injections };
+  });
 }
 
 function toAbsolutePath(file: string): string {
-	if (path.isAbsolute(file)) {
-		return file;
-	}
+  if (path.isAbsolute(file)) {
+    return file;
+  }
 
-	const workspaceFolders = vscode.workspace.workspaceFolders;
-	if (!workspaceFolders || workspaceFolders.length === 0) {
-		throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
-	}
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (!workspaceFolders || workspaceFolders.length === 0) {
+    throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
+  }
 
-	const workspaceRoot = workspaceFolders[0].uri.fsPath;
-	return path.resolve(workspaceRoot, file);
+  const workspaceRoot = workspaceFolders[0].uri.fsPath;
+  return path.resolve(workspaceRoot, file);
 }
 
 async function initLanguage(config: Config): Promise<Language> {
-  log(() => {
-    return `Initializing language: ${config.lang}`;
-  });
   await Parser.init().catch();
   const parser = new Parser();
   const lang = await Parser.Language.load(config.parser);
@@ -199,37 +125,25 @@ async function initLanguage(config: Config): Promise<Language> {
     const injectionText = fs.readFileSync(config.injections, "utf-8");
     injectionQuery = lang.query(injectionText);
   }
-  return {
-    parser,
-    highlightQuery,
-    injectionQuery,
-    semanticTokenTypeMappings: config.semanticTokenTypeMappings,
-  };
+  return { parser, highlightQuery, injectionQuery, semanticTokenTypeMappings: config.semanticTokenTypeMappings };
 }
 
 function convertPosition(pos: Parser.Point): vscode.Position {
   return new vscode.Position(pos.row, pos.column);
+  return new vscode.Position(pos.row, pos.column);
 }
 
 function addPosition(range: vscode.Range, pos: vscode.Position): vscode.Range {
-  const start =
-    range.start.line == 0
-      ? new vscode.Position(
-          range.start.line + pos.line,
-          range.start.character + pos.character
-        )
-      : new vscode.Position(range.start.line + pos.line, range.start.character);
-  const end =
-    range.end.line == 0
-      ? new vscode.Position(
-          range.end.line + pos.line,
-          range.end.character + pos.character
-        )
-      : new vscode.Position(range.end.line + pos.line, range.end.character);
+  const start = (range.start.line == 0)
+    ? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
+    : new vscode.Position(range.start.line + pos.line, range.start.character);
+  const end = (range.end.line == 0)
+    ? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
+    : new vscode.Position(range.end.line + pos.line, range.end.character);
   return new vscode.Range(start, end);
 }
 
-function parseCaptureName(name: string): { type: string; modifiers: string[] } {
+function parseCaptureName(name: string): { type: string, modifiers: string[] } {
   const parts = name.split(".");
   if (parts.length === 0) {
     throw new Error("Capture name is empty.");
@@ -259,20 +173,16 @@ function splitToken(token: Token): Token[] {
     let tokens: Token[] = [];
     // token for the first line, beginning at the start char
     tokens.push({
-      range: new vscode.Range(
-        start,
-        new vscode.Position(start.line, maxLineLength)
-      ),
+      range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
       type: token.type,
-      modifiers: token.modifiers,
+      modifiers: token.modifiers
     });
     // tokens for intermediate lines, spanning from 0 to maxLineLength
     for (let i = 1; i < lineDiff; i++) {
       const middleToken: Token = {
         range: new vscode.Range(
           new vscode.Position(start.line + i, 0),
-          new vscode.Position(start.line + i, maxLineLength)
-        ),
+          new vscode.Position(start.line + i, maxLineLength)),
         type: token.type,
         modifiers: token.modifiers,
       };
@@ -282,7 +192,7 @@ function splitToken(token: Token): Token[] {
     tokens.push({
       range: new vscode.Range(new vscode.Position(end.line, 0), end),
       type: token.type,
-      modifiers: token.modifiers,
+      modifiers: token.modifiers
     });
     return tokens;
   } else {
@@ -294,7 +204,13 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
   private readonly configs: Config[];
   private tsLangs: { [lang: string]: Language } = {};
   private currentLanguage: string = "";
+  private readonly configs: Config[];
+  private tsLangs: { [lang: string]: Language } = {};
+  private currentLanguage: string = "";
 
+  constructor(configs: Config[]) {
+    this.configs = configs;
+  }
   constructor(configs: Config[]) {
     this.configs = configs;
   }
@@ -310,21 +226,15 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
     const lang = document.languageId;
     this.currentLanguage = lang;
     if (!(lang in this.tsLangs)) {
-      const config = this.configs.find((config) => config.lang === lang);
+      const config = this.configs.find(config => config.lang === lang);
       if (config === undefined) {
         throw new Error("No config for lang provided.");
       }
       this.tsLangs[lang] = await initLanguage(config);
     }
-    const tokens = await this.parseToTokens(
-      this.tsLangs[lang],
-      document.getText(),
-      { row: 0, column: 0 }
-    );
+    const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
     const builder = new vscode.SemanticTokensBuilder(LEGEND);
-    tokens.forEach((token) =>
-      builder.push(token.range, token.type, token.modifiers)
-    );
+    tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
     return builder.build();
   }
 
@@ -332,36 +242,26 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
    * Parses the given text with the given language parser and returns the highlighting tokens.
    * Calls `getInjections` for nested injections.
    */
-  async parseToTokens(
-    lang: Language,
-    text: string,
-    startPosition: Parser.Point
-  ): Promise<Token[]> {
+  async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
     const { parser, highlightQuery, injectionQuery } = lang;
     const tree = parser.parse(text);
     const matches = highlightQuery.matches(tree.rootNode);
     let tokens = this.matchesToTokens(matches);
     if (injectionQuery !== undefined) {
-      const injections = await this.getInjections(
-        injectionQuery,
-        tree.rootNode
-      );
+      const injections = await this.getInjections(injectionQuery, tree.rootNode);
       // merge the injection tokens with the main tokens
       for (const injection of injections) {
         if (injection.tokens.length > 0) {
           const range = injection.range;
           tokens = tokens
             // remove all tokens that are contained in an injection
-            .filter((token) => !range.contains(token.range))
+            .filter(token => !range.contains(token.range))
             // split tokens that are partially contained in an injection
-            .flatMap((token) => {
+            .flatMap(token => {
               if (token.range.intersection(range) !== undefined) {
                 let newTokens: Token[] = [];
                 if (token.range.start.isBefore(range.start)) {
-                  const before = new vscode.Range(
-                    token.range.start,
-                    range.start
-                  );
+                  const before = new vscode.Range(token.range.start, range.start);
                   newTokens.push({ ...token, range: before });
                 }
                 if (token.range.end.isAfter(range.end)) {
@@ -375,26 +275,22 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
             });
         }
       }
-      tokens = tokens.concat(
-        injections.map((injection) => injection.tokens).flat()
-      );
+      tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
     }
-    tokens = tokens.map((token) => {
-      return {
-        ...token,
-        range: addPosition(token.range, convertPosition(startPosition)),
-      };
-    });
+    tokens = tokens
+      .map(token => {
+        return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
+      });
     return tokens;
   }
 
   matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
     const unsplitTokens: Token[] = matches
-      .flatMap((match) => match.captures)
-      .flatMap((capture) => {
+      .flatMap(match => match.captures)
+      .flatMap(capture => {
         // Store the original capture name before splitting
         const originalCaptureName = capture.name;
-        let { type, modifiers } = parseCaptureName(capture.name);
+        let { type, modifiers: modifiers } = parseCaptureName(capture.name);
         let start = convertPosition(capture.node.startPosition);
         let end = convertPosition(capture.node.endPosition);
 
@@ -402,66 +298,30 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
         const lang = this.tsLangs[this.currentLanguage];
 
         // First check if we have a mapping for the original unsplit name
-        if (
-          lang?.semanticTokenTypeMappings &&
-          Object.prototype.hasOwnProperty.call(
-            lang.semanticTokenTypeMappings,
-            originalCaptureName
-          )
-        ) {
+        if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, originalCaptureName)) {
           const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
 
           type = mapping.targetTokenType;
           if (mapping.targetTokenModifiers) {
             modifiers = mapping.targetTokenModifiers;
           }
-
-          log(() => {
-            return `Applied type mapping for original name: ${originalCaptureName} → ${
-              mapping.targetTokenType
-            }${
-              mapping.targetTokenModifiers &&
-              mapping.targetTokenModifiers.length > 0
-                ? ` with modifiers: ${mapping.targetTokenModifiers.join(", ")}`
-                : ""
-            }`;
-          });
         }
         // If no mapping for the full name, check for just the type
-        else if (
-          lang?.semanticTokenTypeMappings &&
-          Object.prototype.hasOwnProperty.call(
-            lang.semanticTokenTypeMappings,
-            type
-          )
-        ) {
+        else if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, type)) {
           const mapping = lang.semanticTokenTypeMappings[type];
 
           type = mapping.targetTokenType;
           if (mapping.targetTokenModifiers) {
             modifiers = mapping.targetTokenModifiers;
           }
-
-          log(() => {
-            return `Applied type mapping for base type: ${type} → ${
-              mapping.targetTokenType
-            }${
-              mapping.targetTokenModifiers &&
-              mapping.targetTokenModifiers.length > 0
-                ? ` with modifiers: ${mapping.targetTokenModifiers.join(", ")}`
-                : ""
-            }`;
-          });
         }
 
         if (TOKEN_TYPES.includes(type)) {
-          const validModifiers = modifiers.filter((modifier) =>
-            TOKEN_MODIFIERS.includes(modifier)
-          );
+          const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
           const token: Token = {
             range: new vscode.Range(start, end),
             type: type,
-            modifiers: validModifiers,
+            modifiers: validModifiers
           };
           return token;
         } else {
@@ -469,48 +329,46 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
         }
       });
 
-    return unsplitTokens
-      .flatMap((token) => {
-        // Get all tokens contained within this token
-        const contained = unsplitTokens.filter(
-          (t) => !token.range.isEqual(t.range) && token.range.contains(t.range)
+    return unsplitTokens.flatMap(token => {
+      // Get all tokens contained within this token
+      const contained = unsplitTokens.filter(t =>
+        (!(token.range.isEqual(t.range))) && token.range.contains(t.range)
+      );
+
+      if (contained.length > 0) {
+        // Sort contained tokens by their start position
+        const sortedContained = contained.sort((a, b) =>
+          a.range.start.compareTo(b.range.start)
         );
 
-        if (contained.length > 0) {
-          // Sort contained tokens by their start position
-          const sortedContained = contained.sort((a, b) =>
-            a.range.start.compareTo(b.range.start)
-          );
+        let resultTokens = [];
+        let currentPos = token.range.start;
 
-          let resultTokens = [];
-          let currentPos = token.range.start;
-
-          // Create tokens for the gaps between contained tokens
-          for (const containedToken of sortedContained) {
-            // If there's a gap before this contained token, create a token for it
-            if (currentPos.compareTo(containedToken.range.start) < 0) {
-              resultTokens.push({
-                ...token,
-                range: new vscode.Range(currentPos, containedToken.range.start),
-              });
-            }
-            currentPos = containedToken.range.end;
-          }
-
-          // Add token for the gap after the last contained token if needed
-          if (currentPos.compareTo(token.range.end) < 0) {
+        // Create tokens for the gaps between contained tokens
+        for (const containedToken of sortedContained) {
+          // If there's a gap before this contained token, create a token for it
+          if (currentPos.compareTo(containedToken.range.start) < 0) {
             resultTokens.push({
               ...token,
-              range: new vscode.Range(currentPos, token.range.end),
+              range: new vscode.Range(currentPos, containedToken.range.start),
             });
           }
-
-          return resultTokens;
-        } else {
-          return token;
+          currentPos = containedToken.range.end;
         }
-      })
-      .flatMap(splitToken);
+
+        // Add token for the gap after the last contained token if needed
+        if (currentPos.compareTo(token.range.end) < 0) {
+          resultTokens.push({
+            ...token,
+            range: new vscode.Range(currentPos, token.range.end),
+          });
+        }
+
+        return resultTokens;
+      } else {
+        return token;
+      }
+    }).flatMap(splitToken);
   }
 
   /**
@@ -525,17 +383,14 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
       // "injection.parent": injectionParent
     } = (match as any).setProperties || {};
     // the language is hard coded by "set!"
-    const hardCoded =
-      typeof injectionLanguage == "string" ? injectionLanguage : undefined;
+    const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
     // dynamically determined language
-    const dynamic = match.captures.find(
-      (capture) => capture.name === "injection.language"
-    )?.node.text;
+    const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
     // custom language determination by capture name
-    const name = match.captures.find((capture) =>
-      this.configs.map((config) => config.lang).includes(capture.name)
-    )?.name;
+    const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
 
+    const lang = hardCoded || dynamic || name;
+    if (lang === undefined) return null;
     const lang = hardCoded || dynamic || name;
     if (lang === undefined) return null;
 
@@ -546,32 +401,27 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
       // use first capture (there should only be one)
       capture = match.captures[0];
     } else if (dynamic !== undefined) {
-      capture = match.captures.find(
-        (capture) => capture.name === "injection.content"
-      );
+      capture = match.captures.find(capture => capture.name === "injection.content");
     } else if (name !== undefined) {
-      capture = match.captures.find((capture) => capture.name === name);
+      capture = match.captures.find(capture => capture.name === name);
     }
     if (capture === undefined) return null;
 
     // get language config
-    const config = this.configs.find((config) => config.lang === lang);
+    const config = this.configs.find(config => config.lang === lang);
     if (config === undefined) return null;
 
     if (!(lang in this.tsLangs)) {
       this.tsLangs[lang] = await initLanguage(config);
     }
     const langConfig = this.tsLangs[lang];
+    if (!(lang in this.tsLangs)) {
+      this.tsLangs[lang] = await initLanguage(config);
+    }
+    const langConfig = this.tsLangs[lang];
 
-    let tokens = await this.parseToTokens(
-      langConfig,
-      capture.node.text,
-      capture.node.startPosition
-    );
-    let range = new vscode.Range(
-      convertPosition(capture.node.startPosition),
-      convertPosition(capture.node.endPosition)
-    );
+    let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
+    let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
     return { range, tokens };
   }
 
@@ -579,16 +429,9 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
    * Matches the given injection query against the given node and returns the highlighting tokens.
    * This also works for nested injections.
    */
-  async getInjections(
-    injectionQuery: Parser.Query,
-    node: Parser.SyntaxNode
-  ): Promise<Injection[]> {
+  async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
     const matches = injectionQuery.matches(node);
-    const injections = matches.map(
-      async (match) => await this.getInjection(match)
-    );
-    return (await Promise.all(injections)).filter(
-      (injection): injection is Injection => injection !== null
-    );
+    const injections = matches.map(async match => await this.getInjection(match));
+    return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,132 +1,245 @@
-import * as fs from 'fs';
-import * as vscode from 'vscode';
-import Parser from 'web-tree-sitter';
+import * as fs from "fs";
+import * as vscode from "vscode";
+import Parser from "web-tree-sitter";
+
+const OUTPUT_CHANNEL = vscode.window.createOutputChannel("Tree Sitter");
 
 // VSCode default token types and modifiers from:
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 const TOKEN_TYPES = [
-	'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
-	'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
-	'number', 'regexp', 'operator',
+  "namespace",
+  "class",
+  "enum",
+  "interface",
+  "struct",
+  "typeParameter",
+  "type",
+  "parameter",
+  "variable",
+  "property",
+  "enumMember",
+  "decorator",
+  "event",
+  "function",
+  "method",
+  "macro",
+  "label",
+  "comment",
+  "string",
+  "keyword",
+  "number",
+  "regexp",
+  "operator",
 ];
 const TOKEN_MODIFIERS = [
-	'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
-	'documentation', 'defaultLibrary',
+  "declaration",
+  "definition",
+  "readonly",
+  "static",
+  "deprecated",
+  "abstract",
+  "async",
+  "modification",
+  "documentation",
+  "defaultLibrary",
 ];
 const LEGEND = new vscode.SemanticTokensLegend(TOKEN_TYPES, TOKEN_MODIFIERS);
 
-type Config = { lang: string, parser: string, highlights: string, injections?: string, injectionOnly: boolean };
-type Language = { parser: Parser, highlightQuery: Parser.Query, injectionQuery?: Parser.Query };
-type Token = { range: vscode.Range, type: string, modifiers: string[] };
-type Injection = { range: vscode.Range, tokens: Token[] }
+type SemanticTokenTypeMapping = {
+  targetTokenType: string;
+  targetTokenModifiers?: string[]; // Changed from string to string[]
+};
+type Config = {
+  lang: string;
+  parser: string;
+  highlights: string;
+  injections?: string;
+  injectionOnly: boolean;
+  semanticTokenTypeMappings?: {
+    [sourceSemanticTokenType: string]: SemanticTokenTypeMapping;
+  };
+};
+type Language = {
+  parser: Parser;
+  highlightQuery: Parser.Query;
+  injectionQuery?: Parser.Query;
+  semanticTokenTypeMappings?: {
+    [sourceSemanticTokenType: string]: SemanticTokenTypeMapping;
+  };
+};
+type Token = { range: vscode.Range; type: string; modifiers: string[] };
+type Injection = { range: vscode.Range; tokens: Token[] };
+
+function log(messageOrCallback: string | (() => string), data?: any) {
+  // Only log in debug mode
+  const config = vscode.workspace.getConfiguration("tree-sitter-vscode");
+  const isDebugMode = config.get("debug", false);
+
+  if (isDebugMode) {
+    const timestamp = new Date().toISOString();
+    const message =
+      typeof messageOrCallback === "function"
+        ? messageOrCallback()
+        : messageOrCallback;
+    OUTPUT_CHANNEL.appendLine(`[${timestamp}] ${message}`);
+    if (data) {
+      OUTPUT_CHANNEL.appendLine(JSON.stringify(data, null, 2));
+    }
+  }
+}
 
 /**
  * Called once on extension initialization and again if the reload command is triggered.
  * It reads the configuration and registers the semantic tokens provider.
  */
 export function activate(context: vscode.ExtensionContext) {
-	// setup the semantic tokens provider
-	const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
-	const configs = parseConfigs(rawConfigs);
-	const languageMap = configs
-		.filter(config => !config.injectionOnly)
-		.map(config => { return { language: config.lang }; });
-	const provider = vscode.languages.registerDocumentSemanticTokensProvider(
-		languageMap,
-		new SemanticTokensProvider(configs),
-		LEGEND,
-	)
-	context.subscriptions.push(provider);
+  log("Extension activated");
+  // setup the semantic tokens provider
+  const rawConfigs = vscode.workspace
+    .getConfiguration("tree-sitter-vscode")
+    .get("languageConfigs");
+  const configs = parseConfigs(rawConfigs);
+  log(() => {
+    return `Configured languages: ${configs.map((c) => c.lang).join(", ")}`;
+  });
+  const languageMap = configs
+    .filter((config) => !config.injectionOnly)
+    .map((config) => {
+      return { language: config.lang };
+    });
+  const provider = vscode.languages.registerDocumentSemanticTokensProvider(
+    languageMap,
+    new SemanticTokensProvider(configs),
+    LEGEND
+  );
+  context.subscriptions.push(provider);
 
-	// setup the reload command
-	const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
-		() => {
-			// dispose of the old providers and clear the list of subscriptions
-			reload.dispose();
-			provider.dispose();
-			context.subscriptions.length = 0;
-			// reinitialize the extension
-			activate(context);
-		});
-	context.subscriptions.push(reload);
+  // setup the reload command
+  const reload = vscode.commands.registerCommand(
+    "tree-sitter-vscode.reload",
+    () => {
+      // dispose of the old providers and clear the list of subscriptions
+      reload.dispose();
+      provider.dispose();
+      context.subscriptions.length = 0;
+      // reinitialize the extension
+      activate(context);
+    }
+  );
+  context.subscriptions.push(reload);
 }
 
 /**
  * Called when the extension is deactivated.
  */
-export function deactivate() { }
+export function deactivate() {}
 
 function parseConfigs(configs: any): Config[] {
-	if (!Array.isArray(configs)) {
-		throw new TypeError("Expected a list.");
-	}
-	return configs.map(config => {
-		const lang = config["lang"];
-		const parser = config["parser"];
-		const highlights = config["highlights"];
-		const injections = config["injections"];
-		let injectionOnly = config["injectionOnly"];
-		if (typeof lang !== "string") {
-			throw new TypeError("Expected `lang` to be a string.");
-		}
-		if (typeof parser !== "string") {
-			throw new TypeError("Expected `parser` to be a string.");
-		}
-		if (typeof highlights !== "string") {
-			throw new TypeError("Expected `highlights` to be a string.");
-		}
-		if (injections !== undefined && typeof injections !== "string") {
-			throw new TypeError("Expected `injections` to be a string.");
-		}
-		if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
-			throw new TypeError("Expected `injectionOnly` to be a boolean.");
-		}
-		if (injectionOnly === undefined) {
-			injectionOnly = false;
-		}
-		return { lang, parser, highlights, injections, injectionOnly };
-	});
+  if (!Array.isArray(configs)) {
+    throw new TypeError("Expected a list.");
+  }
+  return configs.map((config) => {
+    const lang = config["lang"];
+    const parser = config["parser"];
+    const highlights = config["highlights"];
+    const injections = config["injections"];
+    let injectionOnly = config["injectionOnly"];
+    const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
+
+    if (typeof lang !== "string") {
+      throw new TypeError("Expected `lang` to be a string.");
+    }
+    if (typeof parser !== "string") {
+      throw new TypeError("Expected `parser` to be a string.");
+    }
+    if (typeof highlights !== "string") {
+      throw new TypeError("Expected `highlights` to be a string.");
+    }
+    if (injections !== undefined && typeof injections !== "string") {
+      throw new TypeError("Expected `injections` to be a string.");
+    }
+    if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
+      throw new TypeError("Expected `injectionOnly` to be a boolean.");
+    }
+    if (
+      semanticTokenTypeMappings !== undefined &&
+      (typeof semanticTokenTypeMappings !== "object" ||
+        semanticTokenTypeMappings === null)
+    ) {
+      throw new TypeError(
+        "Expected `semanticTokenTypeMappings` to be an object."
+      );
+    }
+
+    if (injectionOnly === undefined) {
+      injectionOnly = false;
+    }
+
+    return {
+      lang,
+      parser,
+      highlights,
+      injections,
+      injectionOnly,
+      semanticTokenTypeMappings,
+    };
+  });
 }
 
-
 async function initLanguage(config: Config): Promise<Language> {
-	await Parser.init().catch();
-	const parser = new Parser;
-	const lang = await Parser.Language.load(config.parser);
-	parser.setLanguage(lang);
-	const queryText = fs.readFileSync(config.highlights, "utf-8");
-	const highlightQuery = lang.query(queryText);
-	let injectionQuery = undefined;
-	if (config.injections !== undefined) {
-		const injectionText = fs.readFileSync(config.injections, "utf-8");
-		injectionQuery = lang.query(injectionText);
-	}
-	return { parser, highlightQuery, injectionQuery };
+  log(() => {
+    return `Initializing language: ${config.lang}`;
+  });
+  await Parser.init().catch();
+  const parser = new Parser();
+  const lang = await Parser.Language.load(config.parser);
+  parser.setLanguage(lang);
+  const queryText = fs.readFileSync(config.highlights, "utf-8");
+  const highlightQuery = lang.query(queryText);
+  let injectionQuery = undefined;
+  if (config.injections !== undefined) {
+    const injectionText = fs.readFileSync(config.injections, "utf-8");
+    injectionQuery = lang.query(injectionText);
+  }
+  return {
+    parser,
+    highlightQuery,
+    injectionQuery,
+    semanticTokenTypeMappings: config.semanticTokenTypeMappings,
+  };
 }
 
 function convertPosition(pos: Parser.Point): vscode.Position {
-	return new vscode.Position(pos.row, pos.column);
+  return new vscode.Position(pos.row, pos.column);
 }
 
 function addPosition(range: vscode.Range, pos: vscode.Position): vscode.Range {
-	const start = (range.start.line == 0)
-		? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
-		: new vscode.Position(range.start.line + pos.line, range.start.character);
-	const end = (range.end.line == 0)
-		? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
-		: new vscode.Position(range.end.line + pos.line, range.end.character);
-	return new vscode.Range(start, end);
+  const start =
+    range.start.line == 0
+      ? new vscode.Position(
+          range.start.line + pos.line,
+          range.start.character + pos.character
+        )
+      : new vscode.Position(range.start.line + pos.line, range.start.character);
+  const end =
+    range.end.line == 0
+      ? new vscode.Position(
+          range.end.line + pos.line,
+          range.end.character + pos.character
+        )
+      : new vscode.Position(range.end.line + pos.line, range.end.character);
+  return new vscode.Range(start, end);
 }
 
-function parseCaptureName(name: string): { type: string, modifiers: string[] } {
-	const parts = name.split(".")
-	if (parts.length === 0) {
-		throw new Error("Capture name is empty.");
-	} else if (parts.length === 1) {
-		return { type: parts[0], modifiers: [] };
-	} else {
-		return { type: parts[0], modifiers: parts.slice(1) };
-	}
+function parseCaptureName(name: string): { type: string; modifiers: string[] } {
+  const parts = name.split(".");
+  if (parts.length === 0) {
+    throw new Error("Capture name is empty.");
+  } else if (parts.length === 1) {
+    return { type: parts[0], modifiers: [] };
+  } else {
+    return { type: parts[0], modifiers: parts.slice(1) };
+  }
 }
 
 /**
@@ -135,239 +248,349 @@ function parseCaptureName(name: string): { type: string, modifiers: string[] } {
  * one token for each line is created.
  */
 function splitToken(token: Token): Token[] {
-	const start = token.range.start;
-	const end = token.range.end;
-	if (start.line != end.line) {
-		// 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
-		// Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
-		const maxLineLength = 100_000;
-		const lineDiff = end.line - start.line;
-		if (lineDiff < 0) {
-			throw new RangeError("Invalid token range");
-		}
-		let tokens: Token[] = [];
-		// token for the first line, beginning at the start char
-		tokens.push({
-			range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
-			type: token.type,
-			modifiers: token.modifiers
-		});
-		// tokens for intermediate lines, spanning from 0 to maxLineLength
-		for (let i = 1; i < lineDiff; i++) {
-			const middleToken: Token = {
-				range: new vscode.Range(
-					new vscode.Position(start.line + i, 0),
-					new vscode.Position(start.line + i, maxLineLength)),
-				type: token.type,
-				modifiers: token.modifiers,
-			};
-			tokens.push(middleToken);
-		}
-		// token for the last line, ending at the end char
-		tokens.push({
-			range: new vscode.Range(new vscode.Position(end.line, 0), end),
-			type: token.type,
-			modifiers: token.modifiers
-		});
-		return tokens;
-	} else {
-		return [token];
-	}
+  const start = token.range.start;
+  const end = token.range.end;
+  if (start.line != end.line) {
+    // 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
+    // Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
+    const maxLineLength = 100_000;
+    const lineDiff = end.line - start.line;
+    if (lineDiff < 0) {
+      throw new RangeError("Invalid token range");
+    }
+    let tokens: Token[] = [];
+    // token for the first line, beginning at the start char
+    tokens.push({
+      range: new vscode.Range(
+        start,
+        new vscode.Position(start.line, maxLineLength)
+      ),
+      type: token.type,
+      modifiers: token.modifiers,
+    });
+    // tokens for intermediate lines, spanning from 0 to maxLineLength
+    for (let i = 1; i < lineDiff; i++) {
+      const middleToken: Token = {
+        range: new vscode.Range(
+          new vscode.Position(start.line + i, 0),
+          new vscode.Position(start.line + i, maxLineLength)
+        ),
+        type: token.type,
+        modifiers: token.modifiers,
+      };
+      tokens.push(middleToken);
+    }
+    // token for the last line, ending at the end char
+    tokens.push({
+      range: new vscode.Range(new vscode.Position(end.line, 0), end),
+      type: token.type,
+      modifiers: token.modifiers,
+    });
+    return tokens;
+  } else {
+    return [token];
+  }
 }
 
 class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
-	private readonly configs: Config[];
-	private tsLangs: { [lang: string]: Language } = {};
+  private readonly configs: Config[];
+  private tsLangs: { [lang: string]: Language } = {};
+  private currentLanguage: string = "";
 
-	constructor(configs: Config[]) {
-		this.configs = configs;
-	}
+  constructor(configs: Config[]) {
+    this.configs = configs;
+  }
 
-	/**
-	 * Called regularly by VSCode to provide semantic tokens for the given document.
-	 * It parses the document with the corresponding language parser and returns the tokens.
-	 */
-	async provideDocumentSemanticTokens(
-		document: vscode.TextDocument,
-		token: vscode.CancellationToken
-	) {
-		const lang = document.languageId;
-		if (!(lang in this.tsLangs)) {
-			const config = this.configs.find(config => config.lang === lang);
-			if (config === undefined) {
-				throw new Error("No config for lang provided.");
-			}
-			this.tsLangs[lang] = await initLanguage(config);
-		}
-		const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
-		const builder = new vscode.SemanticTokensBuilder(LEGEND);
-		tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
-		return builder.build();
-	}
+  /**
+   * Called regularly by VSCode to provide semantic tokens for the given document.
+   * It parses the document with the corresponding language parser and returns the tokens.
+   */
+  async provideDocumentSemanticTokens(
+    document: vscode.TextDocument,
+    token: vscode.CancellationToken
+  ) {
+    const lang = document.languageId;
+    this.currentLanguage = lang;
+    if (!(lang in this.tsLangs)) {
+      const config = this.configs.find((config) => config.lang === lang);
+      if (config === undefined) {
+        throw new Error("No config for lang provided.");
+      }
+      this.tsLangs[lang] = await initLanguage(config);
+    }
+    const tokens = await this.parseToTokens(
+      this.tsLangs[lang],
+      document.getText(),
+      { row: 0, column: 0 }
+    );
+    const builder = new vscode.SemanticTokensBuilder(LEGEND);
+    tokens.forEach((token) =>
+      builder.push(token.range, token.type, token.modifiers)
+    );
+    return builder.build();
+  }
 
-	/**
-	 * Parses the given text with the given language parser and returns the highlighting tokens.
-	 * Calls `getInjections` for nested injections.
-	 */
-	async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
-		const { parser, highlightQuery, injectionQuery } = lang;
-		const tree = parser.parse(text);
-		const matches = highlightQuery.matches(tree.rootNode);
-		let tokens = this.matchesToTokens(matches);
-		if (injectionQuery !== undefined) {
-			const injections = await this.getInjections(injectionQuery, tree.rootNode);
-			// merge the injection tokens with the main tokens
-			for (const injection of injections) {
-				if (injection.tokens.length > 0) {
-					const range = injection.range;
-					tokens = tokens
-						// remove all tokens that are contained in an injection
-						.filter(token => !range.contains(token.range))
-						// split tokens that are partially contained in an injection
-						.flatMap(token => {
-							if (token.range.intersection(range) !== undefined) {
-								let newTokens: Token[] = [];
-								if (token.range.start.isBefore(range.start)) {
-									const before = new vscode.Range(token.range.start, range.start);
-									newTokens.push({ ...token, range: before });
-								}
-								if (token.range.end.isAfter(range.end)) {
-									const after = new vscode.Range(range.end, token.range.end);
-									newTokens.push({ ...token, range: after });
-								}
-								return newTokens;
-							} else {
-								return [token];
-							}
-						});
-				}
-			}
-			tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
-		}
-		tokens = tokens
-			.map(token => {
-				return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
-			});
-		return tokens;
-	}
+  /**
+   * Parses the given text with the given language parser and returns the highlighting tokens.
+   * Calls `getInjections` for nested injections.
+   */
+  async parseToTokens(
+    lang: Language,
+    text: string,
+    startPosition: Parser.Point
+  ): Promise<Token[]> {
+    const { parser, highlightQuery, injectionQuery } = lang;
+    const tree = parser.parse(text);
+    const matches = highlightQuery.matches(tree.rootNode);
+    let tokens = this.matchesToTokens(matches);
+    if (injectionQuery !== undefined) {
+      const injections = await this.getInjections(
+        injectionQuery,
+        tree.rootNode
+      );
+      // merge the injection tokens with the main tokens
+      for (const injection of injections) {
+        if (injection.tokens.length > 0) {
+          const range = injection.range;
+          tokens = tokens
+            // remove all tokens that are contained in an injection
+            .filter((token) => !range.contains(token.range))
+            // split tokens that are partially contained in an injection
+            .flatMap((token) => {
+              if (token.range.intersection(range) !== undefined) {
+                let newTokens: Token[] = [];
+                if (token.range.start.isBefore(range.start)) {
+                  const before = new vscode.Range(
+                    token.range.start,
+                    range.start
+                  );
+                  newTokens.push({ ...token, range: before });
+                }
+                if (token.range.end.isAfter(range.end)) {
+                  const after = new vscode.Range(range.end, token.range.end);
+                  newTokens.push({ ...token, range: after });
+                }
+                return newTokens;
+              } else {
+                return [token];
+              }
+            });
+        }
+      }
+      tokens = tokens.concat(
+        injections.map((injection) => injection.tokens).flat()
+      );
+    }
+    tokens = tokens.map((token) => {
+      return {
+        ...token,
+        range: addPosition(token.range, convertPosition(startPosition)),
+      };
+    });
+    return tokens;
+  }
 
-	matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
-		const unsplitTokens: Token[] = matches
-			.flatMap(match => match.captures)
-			.flatMap(capture => {
-				let { type, modifiers: modifiers } = parseCaptureName(capture.name);
-				let start = convertPosition(capture.node.startPosition);
-				let end = convertPosition(capture.node.endPosition);
-				if (TOKEN_TYPES.includes(type)) {
-					const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
-					const token: Token = {
-						range: new vscode.Range(start, end),
-						type: type,
-						modifiers: validModifiers
-					};
-					return token;
-				} else {
-					return [];
-				}
-			});
+  matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
+    const unsplitTokens: Token[] = matches
+      .flatMap((match) => match.captures)
+      .flatMap((capture) => {
+        // Store the original capture name before splitting
+        const originalCaptureName = capture.name;
+        let { type, modifiers } = parseCaptureName(capture.name);
+        let start = convertPosition(capture.node.startPosition);
+        let end = convertPosition(capture.node.endPosition);
 
-		return unsplitTokens.flatMap(token => {
-			// Get all tokens contained within this token
-			const contained = unsplitTokens.filter(t =>
-				(!(token.range.isEqual(t.range))) && token.range.contains(t.range)
-			);
+        // Apply token type mappings, first checking the full capture name
+        const lang = this.tsLangs[this.currentLanguage];
 
-			if (contained.length > 0) {
-				// Sort contained tokens by their start position
-				const sortedContained = contained.sort((a, b) =>
-					a.range.start.compareTo(b.range.start)
-				);
+        // First check if we have a mapping for the original unsplit name
+        if (
+          lang?.semanticTokenTypeMappings &&
+          Object.prototype.hasOwnProperty.call(
+            lang.semanticTokenTypeMappings,
+            originalCaptureName
+          )
+        ) {
+          const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
 
-				let resultTokens = [];
-				let currentPos = token.range.start;
+          type = mapping.targetTokenType;
+          if (mapping.targetTokenModifiers) {
+            modifiers = mapping.targetTokenModifiers;
+          }
 
-				// Create tokens for the gaps between contained tokens
-				for (const containedToken of sortedContained) {
-					// If there's a gap before this contained token, create a token for it
-					if (currentPos.compareTo(containedToken.range.start) < 0) {
-						resultTokens.push({
-							...token,
-							range: new vscode.Range(currentPos, containedToken.range.start),
-						});
-					}
-					currentPos = containedToken.range.end;
-				}
+          log(() => {
+            return `Applied type mapping for original name: ${originalCaptureName} → ${
+              mapping.targetTokenType
+            }${
+              mapping.targetTokenModifiers &&
+              mapping.targetTokenModifiers.length > 0
+                ? ` with modifiers: ${mapping.targetTokenModifiers.join(", ")}`
+                : ""
+            }`;
+          });
+        }
+        // If no mapping for the full name, check for just the type
+        else if (
+          lang?.semanticTokenTypeMappings &&
+          Object.prototype.hasOwnProperty.call(
+            lang.semanticTokenTypeMappings,
+            type
+          )
+        ) {
+          const mapping = lang.semanticTokenTypeMappings[type];
 
-				// Add token for the gap after the last contained token if needed
-				if (currentPos.compareTo(token.range.end) < 0) {
-					resultTokens.push({
-						...token,
-						range: new vscode.Range(currentPos, token.range.end),
-					});
-				}
+          type = mapping.targetTokenType;
+          if (mapping.targetTokenModifiers) {
+            modifiers = mapping.targetTokenModifiers;
+          }
 
-				return resultTokens;
-			} else {
-				return token;
-			}
-		}).flatMap(splitToken);
-	}
+          log(() => {
+            return `Applied type mapping for base type: ${type} → ${
+              mapping.targetTokenType
+            }${
+              mapping.targetTokenModifiers &&
+              mapping.targetTokenModifiers.length > 0
+                ? ` with modifiers: ${mapping.targetTokenModifiers.join(", ")}`
+                : ""
+            }`;
+          });
+        }
 
-	/**
-	 * Get the injection range and tokens for a specific match.
-	 */
-	async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
-		// determine language
-		const {
-			"injection.language": injectionLanguage,
-			// TODO: add support for self and parent injections
-			// "injection.self": injectionSelf,
-			// "injection.parent": injectionParent
-		} = (match as any).setProperties || {};
-		// the language is hard coded by "set!"
-		const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
-		// dynamically determined language
-		const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
-		// custom language determination by capture name
-		const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
+        if (TOKEN_TYPES.includes(type)) {
+          const validModifiers = modifiers.filter((modifier) =>
+            TOKEN_MODIFIERS.includes(modifier)
+          );
+          const token: Token = {
+            range: new vscode.Range(start, end),
+            type: type,
+            modifiers: validModifiers,
+          };
+          return token;
+        } else {
+          return [];
+        }
+      });
 
-		const lang = hardCoded || dynamic || name;
-		if (lang === undefined) return null;
+    return unsplitTokens
+      .flatMap((token) => {
+        // Get all tokens contained within this token
+        const contained = unsplitTokens.filter(
+          (t) => !token.range.isEqual(t.range) && token.range.contains(t.range)
+        );
 
-		// determine capture
-		let capture = undefined;
-		if (hardCoded !== undefined) {
-			if (match.captures.length === 0) return null;
-			// use first capture (there should only be one)
-			capture = match.captures[0];
-		} else if (dynamic !== undefined) {
-			capture = match.captures.find(capture => capture.name === "injection.content");
-		} else if (name !== undefined) {
-			capture = match.captures.find(capture => capture.name === name);
-		}
-		if (capture === undefined) return null;
+        if (contained.length > 0) {
+          // Sort contained tokens by their start position
+          const sortedContained = contained.sort((a, b) =>
+            a.range.start.compareTo(b.range.start)
+          );
 
-		// get language config
-		const config = this.configs.find(config => config.lang === lang);
-		if (config === undefined) return null;
+          let resultTokens = [];
+          let currentPos = token.range.start;
 
-		if (!(lang in this.tsLangs)) {
-			this.tsLangs[lang] = await initLanguage(config);
-		}
-		const langConfig = this.tsLangs[lang];
+          // Create tokens for the gaps between contained tokens
+          for (const containedToken of sortedContained) {
+            // If there's a gap before this contained token, create a token for it
+            if (currentPos.compareTo(containedToken.range.start) < 0) {
+              resultTokens.push({
+                ...token,
+                range: new vscode.Range(currentPos, containedToken.range.start),
+              });
+            }
+            currentPos = containedToken.range.end;
+          }
 
-		let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
-		let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
-		return { range, tokens };
-	}
+          // Add token for the gap after the last contained token if needed
+          if (currentPos.compareTo(token.range.end) < 0) {
+            resultTokens.push({
+              ...token,
+              range: new vscode.Range(currentPos, token.range.end),
+            });
+          }
 
-	/**
-	 * Matches the given injection query against the given node and returns the highlighting tokens.
-	 * This also works for nested injections.
-	 */
-	async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
-		const matches = injectionQuery.matches(node);
-		const injections = matches.map(async match => await this.getInjection(match));
-		return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
-	}
+          return resultTokens;
+        } else {
+          return token;
+        }
+      })
+      .flatMap(splitToken);
+  }
+
+  /**
+   * Get the injection range and tokens for a specific match.
+   */
+  async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
+    // determine language
+    const {
+      "injection.language": injectionLanguage,
+      // TODO: add support for self and parent injections
+      // "injection.self": injectionSelf,
+      // "injection.parent": injectionParent
+    } = (match as any).setProperties || {};
+    // the language is hard coded by "set!"
+    const hardCoded =
+      typeof injectionLanguage == "string" ? injectionLanguage : undefined;
+    // dynamically determined language
+    const dynamic = match.captures.find(
+      (capture) => capture.name === "injection.language"
+    )?.node.text;
+    // custom language determination by capture name
+    const name = match.captures.find((capture) =>
+      this.configs.map((config) => config.lang).includes(capture.name)
+    )?.name;
+
+    const lang = hardCoded || dynamic || name;
+    if (lang === undefined) return null;
+
+    // determine capture
+    let capture = undefined;
+    if (hardCoded !== undefined) {
+      if (match.captures.length === 0) return null;
+      // use first capture (there should only be one)
+      capture = match.captures[0];
+    } else if (dynamic !== undefined) {
+      capture = match.captures.find(
+        (capture) => capture.name === "injection.content"
+      );
+    } else if (name !== undefined) {
+      capture = match.captures.find((capture) => capture.name === name);
+    }
+    if (capture === undefined) return null;
+
+    // get language config
+    const config = this.configs.find((config) => config.lang === lang);
+    if (config === undefined) return null;
+
+    if (!(lang in this.tsLangs)) {
+      this.tsLangs[lang] = await initLanguage(config);
+    }
+    const langConfig = this.tsLangs[lang];
+
+    let tokens = await this.parseToTokens(
+      langConfig,
+      capture.node.text,
+      capture.node.startPosition
+    );
+    let range = new vscode.Range(
+      convertPosition(capture.node.startPosition),
+      convertPosition(capture.node.endPosition)
+    );
+    return { range, tokens };
+  }
+
+  /**
+   * Matches the given injection query against the given node and returns the highlighting tokens.
+   * This also works for nested injections.
+   */
+  async getInjections(
+    injectionQuery: Parser.Query,
+    node: Parser.SyntaxNode
+  ): Promise<Injection[]> {
+    const matches = injectionQuery.matches(node);
+    const injections = matches.map(
+      async (match) => await this.getInjection(match)
+    );
+    return (await Promise.all(injections)).filter(
+      (injection): injection is Injection => injection !== null
+    );
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,13 +6,13 @@ import Parser from 'web-tree-sitter';
 // VSCode default token types and modifiers from:
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 const TOKEN_TYPES = [
-  'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
-  'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
-  'number', 'regexp', 'operator',
+    'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
+    'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
+    'number', 'regexp', 'operator',
 ];
 const TOKEN_MODIFIERS = [
-  'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
-  'documentation', 'defaultLibrary',
+    'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
+    'documentation', 'defaultLibrary',
 ];
 const LEGEND = new vscode.SemanticTokensLegend(TOKEN_TYPES, TOKEN_MODIFIERS);
 
@@ -27,131 +27,131 @@ type Injection = { range: vscode.Range, tokens: Token[] };
  * It reads the configuration and registers the semantic tokens provider.
  */
 export function activate(context: vscode.ExtensionContext) {
-  // setup the semantic tokens provider
-  const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
-  const configs = parseConfigs(rawConfigs);
-  const languageMap = configs
-    .filter(config => !config.injectionOnly)
-    .map(config => { return { language: config.lang }; });
-  const provider = vscode.languages.registerDocumentSemanticTokensProvider(
-    languageMap,
-    new SemanticTokensProvider(configs),
-    LEGEND,
-  );
-  context.subscriptions.push(provider);
+    // setup the semantic tokens provider
+    const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
+    const configs = parseConfigs(rawConfigs);
+    const languageMap = configs
+        .filter(config => !config.injectionOnly)
+        .map(config => { return { language: config.lang }; });
+    const provider = vscode.languages.registerDocumentSemanticTokensProvider(
+        languageMap,
+        new SemanticTokensProvider(configs),
+        LEGEND,
+    );
+    context.subscriptions.push(provider);
 
-  // setup the reload command
-  const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
-    () => {
-      // dispose of the old providers and clear the list of subscriptions
-      reload.dispose();
-      provider.dispose();
-      context.subscriptions.length = 0;
-      // reinitialize the extension
-      activate(context);
-    });
-  context.subscriptions.push(reload);
+    // setup the reload command
+    const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
+        () => {
+            // dispose of the old providers and clear the list of subscriptions
+            reload.dispose();
+            provider.dispose();
+            context.subscriptions.length = 0;
+            // reinitialize the extension
+            activate(context);
+        });
+    context.subscriptions.push(reload);
 }
 
 /**
  * Called when the extension is deactivated.
  */
-export function deactivate() {}
+export function deactivate() { }
 
 function parseConfigs(configs: any): Config[] {
-  if (!Array.isArray(configs)) {
-    throw new TypeError("Expected a list.");
-  }
-  return configs.map(config => {
-    const lang = config["lang"];
-    const parser = config["parser"];
-    const highlights = config["highlights"];
-    const injections = config["injections"];
-    let injectionOnly = config["injectionOnly"];
-    const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
-    if (typeof lang !== "string") {
-      throw new TypeError("Expected `lang` to be a string.");
+    if (!Array.isArray(configs)) {
+        throw new TypeError("Expected a list.");
     }
-    if (typeof parser !== "string") {
-      throw new TypeError("Expected `parser` to be a string.");
-    }
-    if (typeof highlights !== "string") {
-      throw new TypeError("Expected `highlights` to be a string.");
-    }
-    if (injections !== undefined && typeof injections !== "string") {
-      throw new TypeError("Expected `injections` to be a string.");
-    }
-    if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
-      throw new TypeError("Expected `injectionOnly` to be a boolean.");
-    }
-    if (semanticTokenTypeMappings !== undefined && (typeof semanticTokenTypeMappings !== "object" || semanticTokenTypeMappings === null)) {
-      throw new TypeError("Expected `semanticTokenTypeMappings` to be an object.");
-    }
-    if (injectionOnly === undefined) {
-      injectionOnly = false;
-    }
-    return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
-  }).map(config => {
-    const parser = toAbsolutePath(config.parser);
-    const highlights = toAbsolutePath(config.highlights);
-    const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
-    return { ...config, parser, highlights, injections };
-  });
+    return configs.map(config => {
+        const lang = config["lang"];
+        const parser = config["parser"];
+        const highlights = config["highlights"];
+        const injections = config["injections"];
+        let injectionOnly = config["injectionOnly"];
+        const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
+        if (typeof lang !== "string") {
+            throw new TypeError("Expected `lang` to be a string.");
+        }
+        if (typeof parser !== "string") {
+            throw new TypeError("Expected `parser` to be a string.");
+        }
+        if (typeof highlights !== "string") {
+            throw new TypeError("Expected `highlights` to be a string.");
+        }
+        if (injections !== undefined && typeof injections !== "string") {
+            throw new TypeError("Expected `injections` to be a string.");
+        }
+        if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
+            throw new TypeError("Expected `injectionOnly` to be a boolean.");
+        }
+        if (semanticTokenTypeMappings !== undefined && (typeof semanticTokenTypeMappings !== "object" || semanticTokenTypeMappings === null)) {
+            throw new TypeError("Expected `semanticTokenTypeMappings` to be an object.");
+        }
+        if (injectionOnly === undefined) {
+            injectionOnly = false;
+        }
+        return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
+    }).map(config => {
+        const parser = toAbsolutePath(config.parser);
+        const highlights = toAbsolutePath(config.highlights);
+        const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
+        return { ...config, parser, highlights, injections };
+    });
 }
 
 function toAbsolutePath(file: string): string {
-  if (path.isAbsolute(file)) {
-    return file;
-  }
+    if (path.isAbsolute(file)) {
+        return file;
+    }
 
-  const workspaceFolders = vscode.workspace.workspaceFolders;
-  if (!workspaceFolders || workspaceFolders.length === 0) {
-    throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
-  }
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
+    }
 
-  const workspaceRoot = workspaceFolders[0].uri.fsPath;
-  return path.resolve(workspaceRoot, file);
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    return path.resolve(workspaceRoot, file);
 }
 
 async function initLanguage(config: Config): Promise<Language> {
-  await Parser.init().catch();
-  const parser = new Parser();
-  const lang = await Parser.Language.load(config.parser);
-  parser.setLanguage(lang);
-  const queryText = fs.readFileSync(config.highlights, "utf-8");
-  const highlightQuery = lang.query(queryText);
-  let injectionQuery = undefined;
-  if (config.injections !== undefined) {
-    const injectionText = fs.readFileSync(config.injections, "utf-8");
-    injectionQuery = lang.query(injectionText);
-  }
-  return { parser, highlightQuery, injectionQuery, semanticTokenTypeMappings: config.semanticTokenTypeMappings };
+    await Parser.init().catch();
+    const parser = new Parser();
+    const lang = await Parser.Language.load(config.parser);
+    parser.setLanguage(lang);
+    const queryText = fs.readFileSync(config.highlights, "utf-8");
+    const highlightQuery = lang.query(queryText);
+    let injectionQuery = undefined;
+    if (config.injections !== undefined) {
+        const injectionText = fs.readFileSync(config.injections, "utf-8");
+        injectionQuery = lang.query(injectionText);
+    }
+    return { parser, highlightQuery, injectionQuery, semanticTokenTypeMappings: config.semanticTokenTypeMappings };
 }
 
 function convertPosition(pos: Parser.Point): vscode.Position {
-  return new vscode.Position(pos.row, pos.column);
-  return new vscode.Position(pos.row, pos.column);
+    return new vscode.Position(pos.row, pos.column);
+    return new vscode.Position(pos.row, pos.column);
 }
 
 function addPosition(range: vscode.Range, pos: vscode.Position): vscode.Range {
-  const start = (range.start.line == 0)
-    ? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
-    : new vscode.Position(range.start.line + pos.line, range.start.character);
-  const end = (range.end.line == 0)
-    ? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
-    : new vscode.Position(range.end.line + pos.line, range.end.character);
-  return new vscode.Range(start, end);
+    const start = (range.start.line == 0)
+        ? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
+        : new vscode.Position(range.start.line + pos.line, range.start.character);
+    const end = (range.end.line == 0)
+        ? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
+        : new vscode.Position(range.end.line + pos.line, range.end.character);
+    return new vscode.Range(start, end);
 }
 
 function parseCaptureName(name: string): { type: string, modifiers: string[] } {
-  const parts = name.split(".");
-  if (parts.length === 0) {
-    throw new Error("Capture name is empty.");
-  } else if (parts.length === 1) {
-    return { type: parts[0], modifiers: [] };
-  } else {
-    return { type: parts[0], modifiers: parts.slice(1) };
-  }
+    const parts = name.split(".");
+    if (parts.length === 0) {
+        throw new Error("Capture name is empty.");
+    } else if (parts.length === 1) {
+        return { type: parts[0], modifiers: [] };
+    } else {
+        return { type: parts[0], modifiers: parts.slice(1) };
+    }
 }
 
 /**
@@ -160,278 +160,278 @@ function parseCaptureName(name: string): { type: string, modifiers: string[] } {
  * one token for each line is created.
  */
 function splitToken(token: Token): Token[] {
-  const start = token.range.start;
-  const end = token.range.end;
-  if (start.line != end.line) {
-    // 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
-    // Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
-    const maxLineLength = 100_000;
-    const lineDiff = end.line - start.line;
-    if (lineDiff < 0) {
-      throw new RangeError("Invalid token range");
+    const start = token.range.start;
+    const end = token.range.end;
+    if (start.line != end.line) {
+        // 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
+        // Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
+        const maxLineLength = 100_000;
+        const lineDiff = end.line - start.line;
+        if (lineDiff < 0) {
+            throw new RangeError("Invalid token range");
+        }
+        let tokens: Token[] = [];
+        // token for the first line, beginning at the start char
+        tokens.push({
+            range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
+            type: token.type,
+            modifiers: token.modifiers
+        });
+        // tokens for intermediate lines, spanning from 0 to maxLineLength
+        for (let i = 1; i < lineDiff; i++) {
+            const middleToken: Token = {
+                range: new vscode.Range(
+                    new vscode.Position(start.line + i, 0),
+                    new vscode.Position(start.line + i, maxLineLength)),
+                type: token.type,
+                modifiers: token.modifiers,
+            };
+            tokens.push(middleToken);
+        }
+        // token for the last line, ending at the end char
+        tokens.push({
+            range: new vscode.Range(new vscode.Position(end.line, 0), end),
+            type: token.type,
+            modifiers: token.modifiers
+        });
+        return tokens;
+    } else {
+        return [token];
     }
-    let tokens: Token[] = [];
-    // token for the first line, beginning at the start char
-    tokens.push({
-      range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
-      type: token.type,
-      modifiers: token.modifiers
-    });
-    // tokens for intermediate lines, spanning from 0 to maxLineLength
-    for (let i = 1; i < lineDiff; i++) {
-      const middleToken: Token = {
-        range: new vscode.Range(
-          new vscode.Position(start.line + i, 0),
-          new vscode.Position(start.line + i, maxLineLength)),
-        type: token.type,
-        modifiers: token.modifiers,
-      };
-      tokens.push(middleToken);
-    }
-    // token for the last line, ending at the end char
-    tokens.push({
-      range: new vscode.Range(new vscode.Position(end.line, 0), end),
-      type: token.type,
-      modifiers: token.modifiers
-    });
-    return tokens;
-  } else {
-    return [token];
-  }
 }
 
 class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
-  private readonly configs: Config[];
-  private tsLangs: { [lang: string]: Language } = {};
-  private currentLanguage: string = "";
-  private readonly configs: Config[];
-  private tsLangs: { [lang: string]: Language } = {};
-  private currentLanguage: string = "";
+    private readonly configs: Config[];
+    private tsLangs: { [lang: string]: Language } = {};
+    private currentLanguage: string = "";
+    private readonly configs: Config[];
+    private tsLangs: { [lang: string]: Language } = {};
+    private currentLanguage: string = "";
 
-  constructor(configs: Config[]) {
-    this.configs = configs;
-  }
-  constructor(configs: Config[]) {
-    this.configs = configs;
-  }
-
-  /**
-   * Called regularly by VSCode to provide semantic tokens for the given document.
-   * It parses the document with the corresponding language parser and returns the tokens.
-   */
-  async provideDocumentSemanticTokens(
-    document: vscode.TextDocument,
-    token: vscode.CancellationToken
-  ) {
-    const lang = document.languageId;
-    this.currentLanguage = lang;
-    if (!(lang in this.tsLangs)) {
-      const config = this.configs.find(config => config.lang === lang);
-      if (config === undefined) {
-        throw new Error("No config for lang provided.");
-      }
-      this.tsLangs[lang] = await initLanguage(config);
+    constructor(configs: Config[]) {
+        this.configs = configs;
     }
-    const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
-    const builder = new vscode.SemanticTokensBuilder(LEGEND);
-    tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
-    return builder.build();
-  }
+    constructor(configs: Config[]) {
+        this.configs = configs;
+    }
 
-  /**
-   * Parses the given text with the given language parser and returns the highlighting tokens.
-   * Calls `getInjections` for nested injections.
-   */
-  async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
-    const { parser, highlightQuery, injectionQuery } = lang;
-    const tree = parser.parse(text);
-    const matches = highlightQuery.matches(tree.rootNode);
-    let tokens = this.matchesToTokens(matches);
-    if (injectionQuery !== undefined) {
-      const injections = await this.getInjections(injectionQuery, tree.rootNode);
-      // merge the injection tokens with the main tokens
-      for (const injection of injections) {
-        if (injection.tokens.length > 0) {
-          const range = injection.range;
-          tokens = tokens
-            // remove all tokens that are contained in an injection
-            .filter(token => !range.contains(token.range))
-            // split tokens that are partially contained in an injection
-            .flatMap(token => {
-              if (token.range.intersection(range) !== undefined) {
-                let newTokens: Token[] = [];
-                if (token.range.start.isBefore(range.start)) {
-                  const before = new vscode.Range(token.range.start, range.start);
-                  newTokens.push({ ...token, range: before });
+    /**
+     * Called regularly by VSCode to provide semantic tokens for the given document.
+     * It parses the document with the corresponding language parser and returns the tokens.
+     */
+    async provideDocumentSemanticTokens(
+        document: vscode.TextDocument,
+        token: vscode.CancellationToken
+    ) {
+        const lang = document.languageId;
+        this.currentLanguage = lang;
+        if (!(lang in this.tsLangs)) {
+            const config = this.configs.find(config => config.lang === lang);
+            if (config === undefined) {
+                throw new Error("No config for lang provided.");
+            }
+            this.tsLangs[lang] = await initLanguage(config);
+        }
+        const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
+        const builder = new vscode.SemanticTokensBuilder(LEGEND);
+        tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
+        return builder.build();
+    }
+
+    /**
+     * Parses the given text with the given language parser and returns the highlighting tokens.
+     * Calls `getInjections` for nested injections.
+     */
+    async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
+        const { parser, highlightQuery, injectionQuery } = lang;
+        const tree = parser.parse(text);
+        const matches = highlightQuery.matches(tree.rootNode);
+        let tokens = this.matchesToTokens(matches);
+        if (injectionQuery !== undefined) {
+            const injections = await this.getInjections(injectionQuery, tree.rootNode);
+            // merge the injection tokens with the main tokens
+            for (const injection of injections) {
+                if (injection.tokens.length > 0) {
+                    const range = injection.range;
+                    tokens = tokens
+                        // remove all tokens that are contained in an injection
+                        .filter(token => !range.contains(token.range))
+                        // split tokens that are partially contained in an injection
+                        .flatMap(token => {
+                            if (token.range.intersection(range) !== undefined) {
+                                let newTokens: Token[] = [];
+                                if (token.range.start.isBefore(range.start)) {
+                                    const before = new vscode.Range(token.range.start, range.start);
+                                    newTokens.push({ ...token, range: before });
+                                }
+                                if (token.range.end.isAfter(range.end)) {
+                                    const after = new vscode.Range(range.end, token.range.end);
+                                    newTokens.push({ ...token, range: after });
+                                }
+                                return newTokens;
+                            } else {
+                                return [token];
+                            }
+                        });
                 }
-                if (token.range.end.isAfter(range.end)) {
-                  const after = new vscode.Range(range.end, token.range.end);
-                  newTokens.push({ ...token, range: after });
+            }
+            tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
+        }
+        tokens = tokens
+            .map(token => {
+                return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
+            });
+        return tokens;
+    }
+
+    matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
+        const unsplitTokens: Token[] = matches
+            .flatMap(match => match.captures)
+            .flatMap(capture => {
+                // Store the original capture name before splitting
+                const originalCaptureName = capture.name;
+                let { type, modifiers: modifiers } = parseCaptureName(capture.name);
+                let start = convertPosition(capture.node.startPosition);
+                let end = convertPosition(capture.node.endPosition);
+
+                // Apply token type mappings, first checking the full capture name
+                const lang = this.tsLangs[this.currentLanguage];
+
+                // First check if we have a mapping for the original unsplit name
+                if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, originalCaptureName)) {
+                    const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
+
+                    type = mapping.targetTokenType;
+                    if (mapping.targetTokenModifiers) {
+                        modifiers = mapping.targetTokenModifiers;
+                    }
                 }
-                return newTokens;
-              } else {
-                return [token];
-              }
+                // If no mapping for the full name, check for just the type
+                else if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, type)) {
+                    const mapping = lang.semanticTokenTypeMappings[type];
+
+                    type = mapping.targetTokenType;
+                    if (mapping.targetTokenModifiers) {
+                        modifiers = mapping.targetTokenModifiers;
+                    }
+                }
+
+                if (TOKEN_TYPES.includes(type)) {
+                    const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
+                    const token: Token = {
+                        range: new vscode.Range(start, end),
+                        type: type,
+                        modifiers: validModifiers
+                    };
+                    return token;
+                } else {
+                    return [];
+                }
             });
-        }
-      }
-      tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
+
+        return unsplitTokens.flatMap(token => {
+            // Get all tokens contained within this token
+            const contained = unsplitTokens.filter(t =>
+                (!(token.range.isEqual(t.range))) && token.range.contains(t.range)
+            );
+
+            if (contained.length > 0) {
+                // Sort contained tokens by their start position
+                const sortedContained = contained.sort((a, b) =>
+                    a.range.start.compareTo(b.range.start)
+                );
+
+                let resultTokens = [];
+                let currentPos = token.range.start;
+
+                // Create tokens for the gaps between contained tokens
+                for (const containedToken of sortedContained) {
+                    // If there's a gap before this contained token, create a token for it
+                    if (currentPos.compareTo(containedToken.range.start) < 0) {
+                        resultTokens.push({
+                            ...token,
+                            range: new vscode.Range(currentPos, containedToken.range.start),
+                        });
+                    }
+                    currentPos = containedToken.range.end;
+                }
+
+                // Add token for the gap after the last contained token if needed
+                if (currentPos.compareTo(token.range.end) < 0) {
+                    resultTokens.push({
+                        ...token,
+                        range: new vscode.Range(currentPos, token.range.end),
+                    });
+                }
+
+                return resultTokens;
+            } else {
+                return token;
+            }
+        }).flatMap(splitToken);
     }
-    tokens = tokens
-      .map(token => {
-        return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
-      });
-    return tokens;
-  }
 
-  matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
-    const unsplitTokens: Token[] = matches
-      .flatMap(match => match.captures)
-      .flatMap(capture => {
-        // Store the original capture name before splitting
-        const originalCaptureName = capture.name;
-        let { type, modifiers: modifiers } = parseCaptureName(capture.name);
-        let start = convertPosition(capture.node.startPosition);
-        let end = convertPosition(capture.node.endPosition);
+    /**
+     * Get the injection range and tokens for a specific match.
+     */
+    async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
+        // determine language
+        const {
+            "injection.language": injectionLanguage,
+            // TODO: add support for self and parent injections
+            // "injection.self": injectionSelf,
+            // "injection.parent": injectionParent
+        } = (match as any).setProperties || {};
+        // the language is hard coded by "set!"
+        const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
+        // dynamically determined language
+        const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
+        // custom language determination by capture name
+        const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
 
-        // Apply token type mappings, first checking the full capture name
-        const lang = this.tsLangs[this.currentLanguage];
+        const lang = hardCoded || dynamic || name;
+        if (lang === undefined) return null;
+        const lang = hardCoded || dynamic || name;
+        if (lang === undefined) return null;
 
-        // First check if we have a mapping for the original unsplit name
-        if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, originalCaptureName)) {
-          const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
-
-          type = mapping.targetTokenType;
-          if (mapping.targetTokenModifiers) {
-            modifiers = mapping.targetTokenModifiers;
-          }
+        // determine capture
+        let capture = undefined;
+        if (hardCoded !== undefined) {
+            if (match.captures.length === 0) return null;
+            // use first capture (there should only be one)
+            capture = match.captures[0];
+        } else if (dynamic !== undefined) {
+            capture = match.captures.find(capture => capture.name === "injection.content");
+        } else if (name !== undefined) {
+            capture = match.captures.find(capture => capture.name === name);
         }
-        // If no mapping for the full name, check for just the type
-        else if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, type)) {
-          const mapping = lang.semanticTokenTypeMappings[type];
+        if (capture === undefined) return null;
 
-          type = mapping.targetTokenType;
-          if (mapping.targetTokenModifiers) {
-            modifiers = mapping.targetTokenModifiers;
-          }
+        // get language config
+        const config = this.configs.find(config => config.lang === lang);
+        if (config === undefined) return null;
+
+        if (!(lang in this.tsLangs)) {
+            this.tsLangs[lang] = await initLanguage(config);
         }
-
-        if (TOKEN_TYPES.includes(type)) {
-          const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
-          const token: Token = {
-            range: new vscode.Range(start, end),
-            type: type,
-            modifiers: validModifiers
-          };
-          return token;
-        } else {
-          return [];
+        const langConfig = this.tsLangs[lang];
+        if (!(lang in this.tsLangs)) {
+            this.tsLangs[lang] = await initLanguage(config);
         }
-      });
+        const langConfig = this.tsLangs[lang];
 
-    return unsplitTokens.flatMap(token => {
-      // Get all tokens contained within this token
-      const contained = unsplitTokens.filter(t =>
-        (!(token.range.isEqual(t.range))) && token.range.contains(t.range)
-      );
-
-      if (contained.length > 0) {
-        // Sort contained tokens by their start position
-        const sortedContained = contained.sort((a, b) =>
-          a.range.start.compareTo(b.range.start)
-        );
-
-        let resultTokens = [];
-        let currentPos = token.range.start;
-
-        // Create tokens for the gaps between contained tokens
-        for (const containedToken of sortedContained) {
-          // If there's a gap before this contained token, create a token for it
-          if (currentPos.compareTo(containedToken.range.start) < 0) {
-            resultTokens.push({
-              ...token,
-              range: new vscode.Range(currentPos, containedToken.range.start),
-            });
-          }
-          currentPos = containedToken.range.end;
-        }
-
-        // Add token for the gap after the last contained token if needed
-        if (currentPos.compareTo(token.range.end) < 0) {
-          resultTokens.push({
-            ...token,
-            range: new vscode.Range(currentPos, token.range.end),
-          });
-        }
-
-        return resultTokens;
-      } else {
-        return token;
-      }
-    }).flatMap(splitToken);
-  }
-
-  /**
-   * Get the injection range and tokens for a specific match.
-   */
-  async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
-    // determine language
-    const {
-      "injection.language": injectionLanguage,
-      // TODO: add support for self and parent injections
-      // "injection.self": injectionSelf,
-      // "injection.parent": injectionParent
-    } = (match as any).setProperties || {};
-    // the language is hard coded by "set!"
-    const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
-    // dynamically determined language
-    const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
-    // custom language determination by capture name
-    const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
-
-    const lang = hardCoded || dynamic || name;
-    if (lang === undefined) return null;
-    const lang = hardCoded || dynamic || name;
-    if (lang === undefined) return null;
-
-    // determine capture
-    let capture = undefined;
-    if (hardCoded !== undefined) {
-      if (match.captures.length === 0) return null;
-      // use first capture (there should only be one)
-      capture = match.captures[0];
-    } else if (dynamic !== undefined) {
-      capture = match.captures.find(capture => capture.name === "injection.content");
-    } else if (name !== undefined) {
-      capture = match.captures.find(capture => capture.name === name);
+        let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
+        let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
+        return { range, tokens };
     }
-    if (capture === undefined) return null;
 
-    // get language config
-    const config = this.configs.find(config => config.lang === lang);
-    if (config === undefined) return null;
-
-    if (!(lang in this.tsLangs)) {
-      this.tsLangs[lang] = await initLanguage(config);
+    /**
+     * Matches the given injection query against the given node and returns the highlighting tokens.
+     * This also works for nested injections.
+     */
+    async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
+        const matches = injectionQuery.matches(node);
+        const injections = matches.map(async match => await this.getInjection(match));
+        return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
     }
-    const langConfig = this.tsLangs[lang];
-    if (!(lang in this.tsLangs)) {
-      this.tsLangs[lang] = await initLanguage(config);
-    }
-    const langConfig = this.tsLangs[lang];
-
-    let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
-    let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
-    return { range, tokens };
-  }
-
-  /**
-   * Matches the given injection query against the given node and returns the highlighting tokens.
-   * This also works for nested injections.
-   */
-  async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
-    const matches = injectionQuery.matches(node);
-    const injections = matches.map(async match => await this.getInjection(match));
-    return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
-  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,13 +7,41 @@ import Parser from 'web-tree-sitter';
 // VSCode default token types and modifiers from:
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 const TOKEN_TYPES = [
-	'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
-	'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
-	'number', 'regexp', 'operator',
+  "namespace",
+  "class",
+  "enum",
+  "interface",
+  "struct",
+  "typeParameter",
+  "type",
+  "parameter",
+  "variable",
+  "property",
+  "enumMember",
+  "decorator",
+  "event",
+  "function",
+  "method",
+  "macro",
+  "label",
+  "comment",
+  "string",
+  "keyword",
+  "number",
+  "regexp",
+  "operator",
 ];
 const TOKEN_MODIFIERS = [
-	'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
-	'documentation', 'defaultLibrary',
+  "declaration",
+  "definition",
+  "readonly",
+  "static",
+  "deprecated",
+  "abstract",
+  "async",
+  "modification",
+  "documentation",
+  "defaultLibrary",
 ];
 const LEGEND = new vscode.SemanticTokensLegend(TOKEN_TYPES, TOKEN_MODIFIERS);
 
@@ -41,23 +69,25 @@ export function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(provider);
 
-	// setup the reload command
-	const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
-		() => {
-			// dispose of the old providers and clear the list of subscriptions
-			reload.dispose();
-			provider.dispose();
-			context.subscriptions.length = 0;
-			// reinitialize the extension
-			activate(context);
-		});
-	context.subscriptions.push(reload);
+  // setup the reload command
+  const reload = vscode.commands.registerCommand(
+    "tree-sitter-vscode.reload",
+    () => {
+      // dispose of the old providers and clear the list of subscriptions
+      reload.dispose();
+      provider.dispose();
+      context.subscriptions.length = 0;
+      // reinitialize the extension
+      activate(context);
+    }
+  );
+  context.subscriptions.push(reload);
 }
 
 /**
  * Called when the extension is deactivated.
  */
-export function deactivate() { }
+export function deactivate() {}
 
 function parseConfigs(configs: any): Config[] {
 	if (!Array.isArray(configs)) {
@@ -114,7 +144,6 @@ function toAbsolutePath(file: string): string {
 	return path.resolve(workspaceRoot, file);
 }
 
-
 async function initLanguage(config: Config): Promise<Language> {
 	await Parser.init().catch();
 	const parser = new Parser();
@@ -136,13 +165,21 @@ function convertPosition(pos: Parser.Point): vscode.Position {
 }
 
 function addPosition(range: vscode.Range, pos: vscode.Position): vscode.Range {
-	const start = (range.start.line == 0)
-		? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
-		: new vscode.Position(range.start.line + pos.line, range.start.character);
-	const end = (range.end.line == 0)
-		? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
-		: new vscode.Position(range.end.line + pos.line, range.end.character);
-	return new vscode.Range(start, end);
+  const start =
+    range.start.line == 0
+      ? new vscode.Position(
+          range.start.line + pos.line,
+          range.start.character + pos.character
+        )
+      : new vscode.Position(range.start.line + pos.line, range.start.character);
+  const end =
+    range.end.line == 0
+      ? new vscode.Position(
+          range.end.line + pos.line,
+          range.end.character + pos.character
+        )
+      : new vscode.Position(range.end.line + pos.line, range.end.character);
+  return new vscode.Range(start, end);
 }
 
 function parseCaptureName(name: string): { type: string, modifiers: string[] } {
@@ -162,44 +199,48 @@ function parseCaptureName(name: string): { type: string, modifiers: string[] } {
  * one token for each line is created.
  */
 function splitToken(token: Token): Token[] {
-	const start = token.range.start;
-	const end = token.range.end;
-	if (start.line != end.line) {
-		// 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
-		// Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
-		const maxLineLength = 100_000;
-		const lineDiff = end.line - start.line;
-		if (lineDiff < 0) {
-			throw new RangeError("Invalid token range");
-		}
-		let tokens: Token[] = [];
-		// token for the first line, beginning at the start char
-		tokens.push({
-			range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
-			type: token.type,
-			modifiers: token.modifiers
-		});
-		// tokens for intermediate lines, spanning from 0 to maxLineLength
-		for (let i = 1; i < lineDiff; i++) {
-			const middleToken: Token = {
-				range: new vscode.Range(
-					new vscode.Position(start.line + i, 0),
-					new vscode.Position(start.line + i, maxLineLength)),
-				type: token.type,
-				modifiers: token.modifiers,
-			};
-			tokens.push(middleToken);
-		}
-		// token for the last line, ending at the end char
-		tokens.push({
-			range: new vscode.Range(new vscode.Position(end.line, 0), end),
-			type: token.type,
-			modifiers: token.modifiers
-		});
-		return tokens;
-	} else {
-		return [token];
-	}
+  const start = token.range.start;
+  const end = token.range.end;
+  if (start.line != end.line) {
+    // 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
+    // Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
+    const maxLineLength = 100_000;
+    const lineDiff = end.line - start.line;
+    if (lineDiff < 0) {
+      throw new RangeError("Invalid token range");
+    }
+    let tokens: Token[] = [];
+    // token for the first line, beginning at the start char
+    tokens.push({
+      range: new vscode.Range(
+        start,
+        new vscode.Position(start.line, maxLineLength)
+      ),
+      type: token.type,
+      modifiers: token.modifiers,
+    });
+    // tokens for intermediate lines, spanning from 0 to maxLineLength
+    for (let i = 1; i < lineDiff; i++) {
+      const middleToken: Token = {
+        range: new vscode.Range(
+          new vscode.Position(start.line + i, 0),
+          new vscode.Position(start.line + i, maxLineLength)
+        ),
+        type: token.type,
+        modifiers: token.modifiers,
+      };
+      tokens.push(middleToken);
+    }
+    // token for the last line, ending at the end char
+    tokens.push({
+      range: new vscode.Range(new vscode.Position(end.line, 0), end),
+      type: token.type,
+      modifiers: token.modifiers,
+    });
+    return tokens;
+  } else {
+    return [token];
+  }
 }
 
 class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
@@ -240,51 +281,65 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
 		return builder.build();
 	}
 
-	/**
-	 * Parses the given text with the given language parser and returns the highlighting tokens.
-	 * Calls `getInjections` for nested injections.
-	 */
-	async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
-		const { parser, highlightQuery, injectionQuery } = lang;
-		const tree = parser.parse(text);
-		const matches = highlightQuery.matches(tree.rootNode);
-		let tokens = this.matchesToTokens(matches);
-		if (injectionQuery !== undefined) {
-			const injections = await this.getInjections(injectionQuery, tree.rootNode);
-			// merge the injection tokens with the main tokens
-			for (const injection of injections) {
-				if (injection.tokens.length > 0) {
-					const range = injection.range;
-					tokens = tokens
-						// remove all tokens that are contained in an injection
-						.filter(token => !range.contains(token.range))
-						// split tokens that are partially contained in an injection
-						.flatMap(token => {
-							if (token.range.intersection(range) !== undefined) {
-								let newTokens: Token[] = [];
-								if (token.range.start.isBefore(range.start)) {
-									const before = new vscode.Range(token.range.start, range.start);
-									newTokens.push({ ...token, range: before });
-								}
-								if (token.range.end.isAfter(range.end)) {
-									const after = new vscode.Range(range.end, token.range.end);
-									newTokens.push({ ...token, range: after });
-								}
-								return newTokens;
-							} else {
-								return [token];
-							}
-						});
-				}
-			}
-			tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
-		}
-		tokens = tokens
-			.map(token => {
-				return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
-			});
-		return tokens;
-	}
+  /**
+   * Parses the given text with the given language parser and returns the highlighting tokens.
+   * Calls `getInjections` for nested injections.
+   */
+  async parseToTokens(
+    lang: Language,
+    text: string,
+    startPosition: Parser.Point
+  ): Promise<Token[]> {
+    const { parser, highlightQuery, injectionQuery } = lang;
+    const tree = parser.parse(text);
+    const matches = highlightQuery.matches(tree.rootNode);
+    let tokens = this.matchesToTokens(matches);
+    if (injectionQuery !== undefined) {
+      const injections = await this.getInjections(
+        injectionQuery,
+        tree.rootNode
+      );
+      // merge the injection tokens with the main tokens
+      for (const injection of injections) {
+        if (injection.tokens.length > 0) {
+          const range = injection.range;
+          tokens = tokens
+            // remove all tokens that are contained in an injection
+            .filter((token) => !range.contains(token.range))
+            // split tokens that are partially contained in an injection
+            .flatMap((token) => {
+              if (token.range.intersection(range) !== undefined) {
+                let newTokens: Token[] = [];
+                if (token.range.start.isBefore(range.start)) {
+                  const before = new vscode.Range(
+                    token.range.start,
+                    range.start
+                  );
+                  newTokens.push({ ...token, range: before });
+                }
+                if (token.range.end.isAfter(range.end)) {
+                  const after = new vscode.Range(range.end, token.range.end);
+                  newTokens.push({ ...token, range: after });
+                }
+                return newTokens;
+              } else {
+                return [token];
+              }
+            });
+        }
+      }
+      tokens = tokens.concat(
+        injections.map((injection) => injection.tokens).flat()
+      );
+    }
+    tokens = tokens.map((token) => {
+      return {
+        ...token,
+        range: addPosition(token.range, convertPosition(startPosition)),
+      };
+    });
+    return tokens;
+  }
 
 	matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
 		const unsplitTokens: Token[] = matches
@@ -331,87 +386,96 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
 				}
 			});
 
-		return unsplitTokens.flatMap(token => {
-			// Get all tokens contained within this token
-			const contained = unsplitTokens.filter(t =>
-				(!(token.range.isEqual(t.range))) && token.range.contains(t.range)
-			);
+    return unsplitTokens
+      .flatMap((token) => {
+        // Get all tokens contained within this token
+        const contained = unsplitTokens.filter(
+          (t) => !token.range.isEqual(t.range) && token.range.contains(t.range)
+        );
 
-			if (contained.length > 0) {
-				// Sort contained tokens by their start position
-				const sortedContained = contained.sort((a, b) =>
-					a.range.start.compareTo(b.range.start)
-				);
+        if (contained.length > 0) {
+          // Sort contained tokens by their start position
+          const sortedContained = contained.sort((a, b) =>
+            a.range.start.compareTo(b.range.start)
+          );
 
-				let resultTokens = [];
-				let currentPos = token.range.start;
+          let resultTokens = [];
+          let currentPos = token.range.start;
 
-				// Create tokens for the gaps between contained tokens
-				for (const containedToken of sortedContained) {
-					// If there's a gap before this contained token, create a token for it
-					if (currentPos.compareTo(containedToken.range.start) < 0) {
-						resultTokens.push({
-							...token,
-							range: new vscode.Range(currentPos, containedToken.range.start),
-						});
-					}
-					currentPos = containedToken.range.end;
-				}
+          // Create tokens for the gaps between contained tokens
+          for (const containedToken of sortedContained) {
+            // If there's a gap before this contained token, create a token for it
+            if (currentPos.compareTo(containedToken.range.start) < 0) {
+              resultTokens.push({
+                ...token,
+                range: new vscode.Range(currentPos, containedToken.range.start),
+              });
+            }
+            currentPos = containedToken.range.end;
+          }
 
-				// Add token for the gap after the last contained token if needed
-				if (currentPos.compareTo(token.range.end) < 0) {
-					resultTokens.push({
-						...token,
-						range: new vscode.Range(currentPos, token.range.end),
-					});
-				}
+          // Add token for the gap after the last contained token if needed
+          if (currentPos.compareTo(token.range.end) < 0) {
+            resultTokens.push({
+              ...token,
+              range: new vscode.Range(currentPos, token.range.end),
+            });
+          }
 
-				return resultTokens;
-			} else {
-				return token;
-			}
-		}).flatMap(splitToken);
-	}
+          return resultTokens;
+        } else {
+          return token;
+        }
+      })
+      .flatMap(splitToken);
+  }
 
-	/**
-	 * Get the injection range and tokens for a specific match.
-	 */
-	async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
-		// determine language
-		const {
-			"injection.language": injectionLanguage,
-			// TODO: add support for self and parent injections
-			// "injection.self": injectionSelf,
-			// "injection.parent": injectionParent
-		} = (match as any).setProperties || {};
-		// the language is hard coded by "set!"
-		const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
-		// dynamically determined language
-		const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
-		// custom language determination by capture name
-		const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
+  /**
+   * Get the injection range and tokens for a specific match.
+   */
+  async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
+    // determine language
+    const {
+      "injection.language": injectionLanguage,
+      // TODO: add support for self and parent injections
+      // "injection.self": injectionSelf,
+      // "injection.parent": injectionParent
+    } = (match as any).setProperties || {};
+    // the language is hard coded by "set!"
+    const hardCoded =
+      typeof injectionLanguage == "string" ? injectionLanguage : undefined;
+    // dynamically determined language
+    const dynamic = match.captures.find(
+      (capture) => capture.name === "injection.language"
+    )?.node.text;
+    // custom language determination by capture name
+    const name = match.captures.find((capture) =>
+      this.configs.map((config) => config.lang).includes(capture.name)
+    )?.name;
 
 		const lang = hardCoded || dynamic || name;
 		if (lang === undefined) return null;
 		const lang = hardCoded || dynamic || name;
 		if (lang === undefined) return null;
 
-		// determine capture
-		let capture = undefined;
-		if (hardCoded !== undefined) {
-			if (match.captures.length === 0) return null;
-			// use first capture (there should only be one)
-			capture = match.captures[0];
-		} else if (dynamic !== undefined) {
-			capture = match.captures.find(capture => capture.name === "injection.content");
-		} else if (name !== undefined) {
-			capture = match.captures.find(capture => capture.name === name);
-		}
-		if (capture === undefined) return null;
+    // determine capture
+    let capture = undefined;
+    if (hardCoded !== undefined) {
+      if (match.captures.length === 0) return null;
+      // use first capture (there should only be one)
+      capture = match.captures[0];
+    } else if (dynamic !== undefined) {
+      capture = match.captures.find(
+        (capture) => capture.name === "injection.content"
+      );
+    } else if (name !== undefined) {
+      capture = match.captures.find((capture) => capture.name === name);
+    }
+    if (capture === undefined) return null;
 
-		// get language config
-		const config = this.configs.find(config => config.lang === lang);
-		if (config === undefined) return null;
+    // get language config
+    const config = this.configs.find((config) => config.lang === lang);
+    if (config === undefined) return null;
 
 		if (!(lang in this.tsLangs)) {
 			this.tsLangs[lang] = await initLanguage(config);
@@ -422,18 +486,32 @@ class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
 		}
 		const langConfig = this.tsLangs[lang];
 
-		let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
-		let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
-		return { range, tokens };
-	}
+    let tokens = await this.parseToTokens(
+      langConfig,
+      capture.node.text,
+      capture.node.startPosition
+    );
+    let range = new vscode.Range(
+      convertPosition(capture.node.startPosition),
+      convertPosition(capture.node.endPosition)
+    );
+    return { range, tokens };
+  }
 
-	/**
-	 * Matches the given injection query against the given node and returns the highlighting tokens.
-	 * This also works for nested injections.
-	 */
-	async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
-		const matches = injectionQuery.matches(node);
-		const injections = matches.map(async match => await this.getInjection(match));
-		return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
-	}
+  /**
+   * Matches the given injection query against the given node and returns the highlighting tokens.
+   * This also works for nested injections.
+   */
+  async getInjections(
+    injectionQuery: Parser.Query,
+    node: Parser.SyntaxNode
+  ): Promise<Injection[]> {
+    const matches = injectionQuery.matches(node);
+    const injections = matches.map(
+      async (match) => await this.getInjection(match)
+    );
+    return (await Promise.all(injections)).filter(
+      (injection): injection is Injection => injection !== null
+    );
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import path from 'path';
+import path from 'path';
 import * as vscode from 'vscode';
 import Parser from 'web-tree-sitter';
 
@@ -90,7 +91,7 @@ function parseConfigs(configs: any): Config[] {
 		if (injectionOnly === undefined) {
 			injectionOnly = false;
 		}
-		return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
+		return { lang, parser, highlights, injections, injectionOnly };
 	}).map(config => {
 		const parser = toAbsolutePath(config.parser);
 		const highlights = toAbsolutePath(config.highlights);
@@ -112,6 +113,7 @@ function toAbsolutePath(file: string): string {
 	const workspaceRoot = workspaceFolders[0].uri.fsPath;
 	return path.resolve(workspaceRoot, file);
 }
+
 
 async function initLanguage(config: Config): Promise<Language> {
 	await Parser.init().catch();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,13 +6,13 @@ import Parser from 'web-tree-sitter';
 // VSCode default token types and modifiers from:
 // https://code.visualstudio.com/api/language-extensions/semantic-highlight-guide#standard-token-types-and-modifiers
 const TOKEN_TYPES = [
-    'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
-    'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
-    'number', 'regexp', 'operator',
+	'namespace', 'class', 'enum', 'interface', 'struct', 'typeParameter', 'type', 'parameter', 'variable', 'property',
+	'enumMember', 'decorator', 'event', 'function', 'method', 'macro', 'label', 'comment', 'string', 'keyword',
+	'number', 'regexp', 'operator',
 ];
 const TOKEN_MODIFIERS = [
-    'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
-    'documentation', 'defaultLibrary',
+	'declaration', 'definition', 'readonly', 'static', 'deprecated', 'abstract', 'async', 'modification',
+	'documentation', 'defaultLibrary',
 ];
 const LEGEND = new vscode.SemanticTokensLegend(TOKEN_TYPES, TOKEN_MODIFIERS);
 
@@ -27,30 +27,30 @@ type Injection = { range: vscode.Range, tokens: Token[] };
  * It reads the configuration and registers the semantic tokens provider.
  */
 export function activate(context: vscode.ExtensionContext) {
-    // setup the semantic tokens provider
-    const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
-    const configs = parseConfigs(rawConfigs);
-    const languageMap = configs
-        .filter(config => !config.injectionOnly)
-        .map(config => { return { language: config.lang }; });
-    const provider = vscode.languages.registerDocumentSemanticTokensProvider(
-        languageMap,
-        new SemanticTokensProvider(configs),
-        LEGEND,
-    );
-    context.subscriptions.push(provider);
+	// setup the semantic tokens provider
+	const rawConfigs = vscode.workspace.getConfiguration("tree-sitter-vscode").get("languageConfigs");
+	const configs = parseConfigs(rawConfigs);
+	const languageMap = configs
+		.filter(config => !config.injectionOnly)
+		.map(config => { return { language: config.lang }; });
+	const provider = vscode.languages.registerDocumentSemanticTokensProvider(
+		languageMap,
+		new SemanticTokensProvider(configs),
+		LEGEND,
+	);
+	context.subscriptions.push(provider);
 
-    // setup the reload command
-    const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
-        () => {
-            // dispose of the old providers and clear the list of subscriptions
-            reload.dispose();
-            provider.dispose();
-            context.subscriptions.length = 0;
-            // reinitialize the extension
-            activate(context);
-        });
-    context.subscriptions.push(reload);
+	// setup the reload command
+	const reload = vscode.commands.registerCommand("tree-sitter-vscode.reload",
+		() => {
+			// dispose of the old providers and clear the list of subscriptions
+			reload.dispose();
+			provider.dispose();
+			context.subscriptions.length = 0;
+			// reinitialize the extension
+			activate(context);
+		});
+	context.subscriptions.push(reload);
 }
 
 /**
@@ -59,99 +59,99 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() { }
 
 function parseConfigs(configs: any): Config[] {
-    if (!Array.isArray(configs)) {
-        throw new TypeError("Expected a list.");
-    }
-    return configs.map(config => {
-        const lang = config["lang"];
-        const parser = config["parser"];
-        const highlights = config["highlights"];
-        const injections = config["injections"];
-        let injectionOnly = config["injectionOnly"];
-        const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
-        if (typeof lang !== "string") {
-            throw new TypeError("Expected `lang` to be a string.");
-        }
-        if (typeof parser !== "string") {
-            throw new TypeError("Expected `parser` to be a string.");
-        }
-        if (typeof highlights !== "string") {
-            throw new TypeError("Expected `highlights` to be a string.");
-        }
-        if (injections !== undefined && typeof injections !== "string") {
-            throw new TypeError("Expected `injections` to be a string.");
-        }
-        if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
-            throw new TypeError("Expected `injectionOnly` to be a boolean.");
-        }
-        if (semanticTokenTypeMappings !== undefined && (typeof semanticTokenTypeMappings !== "object" || semanticTokenTypeMappings === null)) {
-            throw new TypeError("Expected `semanticTokenTypeMappings` to be an object.");
-        }
-        if (injectionOnly === undefined) {
-            injectionOnly = false;
-        }
-        return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
-    }).map(config => {
-        const parser = toAbsolutePath(config.parser);
-        const highlights = toAbsolutePath(config.highlights);
-        const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
-        return { ...config, parser, highlights, injections };
-    });
+	if (!Array.isArray(configs)) {
+		throw new TypeError("Expected a list.");
+	}
+	return configs.map(config => {
+		const lang = config["lang"];
+		const parser = config["parser"];
+		const highlights = config["highlights"];
+		const injections = config["injections"];
+		let injectionOnly = config["injectionOnly"];
+		const semanticTokenTypeMappings = config["semanticTokenTypeMappings"];
+		if (typeof lang !== "string") {
+			throw new TypeError("Expected `lang` to be a string.");
+		}
+		if (typeof parser !== "string") {
+			throw new TypeError("Expected `parser` to be a string.");
+		}
+		if (typeof highlights !== "string") {
+			throw new TypeError("Expected `highlights` to be a string.");
+		}
+		if (injections !== undefined && typeof injections !== "string") {
+			throw new TypeError("Expected `injections` to be a string.");
+		}
+		if (injectionOnly !== undefined && typeof injectionOnly !== "boolean") {
+			throw new TypeError("Expected `injectionOnly` to be a boolean.");
+		}
+		if (semanticTokenTypeMappings !== undefined && (typeof semanticTokenTypeMappings !== "object" || semanticTokenTypeMappings === null)) {
+			throw new TypeError("Expected `semanticTokenTypeMappings` to be an object.");
+		}
+		if (injectionOnly === undefined) {
+			injectionOnly = false;
+		}
+		return { lang, parser, highlights, injections, injectionOnly, semanticTokenTypeMappings };
+	}).map(config => {
+		const parser = toAbsolutePath(config.parser);
+		const highlights = toAbsolutePath(config.highlights);
+		const injections = config.injections !== undefined ? toAbsolutePath(config.injections) : undefined;
+		return { ...config, parser, highlights, injections };
+	});
 }
 
 function toAbsolutePath(file: string): string {
-    if (path.isAbsolute(file)) {
-        return file;
-    }
+	if (path.isAbsolute(file)) {
+		return file;
+	}
 
-    const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (!workspaceFolders || workspaceFolders.length === 0) {
-        throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
-    }
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+	if (!workspaceFolders || workspaceFolders.length === 0) {
+		throw new Error("Trying to resolve a relative path, but no workspace folder is open.");
+	}
 
-    const workspaceRoot = workspaceFolders[0].uri.fsPath;
-    return path.resolve(workspaceRoot, file);
+	const workspaceRoot = workspaceFolders[0].uri.fsPath;
+	return path.resolve(workspaceRoot, file);
 }
 
 async function initLanguage(config: Config): Promise<Language> {
-    await Parser.init().catch();
-    const parser = new Parser();
-    const lang = await Parser.Language.load(config.parser);
-    parser.setLanguage(lang);
-    const queryText = fs.readFileSync(config.highlights, "utf-8");
-    const highlightQuery = lang.query(queryText);
-    let injectionQuery = undefined;
-    if (config.injections !== undefined) {
-        const injectionText = fs.readFileSync(config.injections, "utf-8");
-        injectionQuery = lang.query(injectionText);
-    }
-    return { parser, highlightQuery, injectionQuery, semanticTokenTypeMappings: config.semanticTokenTypeMappings };
+	await Parser.init().catch();
+	const parser = new Parser();
+	const lang = await Parser.Language.load(config.parser);
+	parser.setLanguage(lang);
+	const queryText = fs.readFileSync(config.highlights, "utf-8");
+	const highlightQuery = lang.query(queryText);
+	let injectionQuery = undefined;
+	if (config.injections !== undefined) {
+		const injectionText = fs.readFileSync(config.injections, "utf-8");
+		injectionQuery = lang.query(injectionText);
+	}
+	return { parser, highlightQuery, injectionQuery, semanticTokenTypeMappings: config.semanticTokenTypeMappings };
 }
 
 function convertPosition(pos: Parser.Point): vscode.Position {
-    return new vscode.Position(pos.row, pos.column);
-    return new vscode.Position(pos.row, pos.column);
+	return new vscode.Position(pos.row, pos.column);
+	return new vscode.Position(pos.row, pos.column);
 }
 
 function addPosition(range: vscode.Range, pos: vscode.Position): vscode.Range {
-    const start = (range.start.line == 0)
-        ? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
-        : new vscode.Position(range.start.line + pos.line, range.start.character);
-    const end = (range.end.line == 0)
-        ? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
-        : new vscode.Position(range.end.line + pos.line, range.end.character);
-    return new vscode.Range(start, end);
+	const start = (range.start.line == 0)
+		? new vscode.Position(range.start.line + pos.line, range.start.character + pos.character)
+		: new vscode.Position(range.start.line + pos.line, range.start.character);
+	const end = (range.end.line == 0)
+		? new vscode.Position(range.end.line + pos.line, range.end.character + pos.character)
+		: new vscode.Position(range.end.line + pos.line, range.end.character);
+	return new vscode.Range(start, end);
 }
 
 function parseCaptureName(name: string): { type: string, modifiers: string[] } {
-    const parts = name.split(".");
-    if (parts.length === 0) {
-        throw new Error("Capture name is empty.");
-    } else if (parts.length === 1) {
-        return { type: parts[0], modifiers: [] };
-    } else {
-        return { type: parts[0], modifiers: parts.slice(1) };
-    }
+	const parts = name.split(".");
+	if (parts.length === 0) {
+		throw new Error("Capture name is empty.");
+	} else if (parts.length === 1) {
+		return { type: parts[0], modifiers: [] };
+	} else {
+		return { type: parts[0], modifiers: parts.slice(1) };
+	}
 }
 
 /**
@@ -160,278 +160,278 @@ function parseCaptureName(name: string): { type: string, modifiers: string[] } {
  * one token for each line is created.
  */
 function splitToken(token: Token): Token[] {
-    const start = token.range.start;
-    const end = token.range.end;
-    if (start.line != end.line) {
-        // 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
-        // Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
-        const maxLineLength = 100_000;
-        const lineDiff = end.line - start.line;
-        if (lineDiff < 0) {
-            throw new RangeError("Invalid token range");
-        }
-        let tokens: Token[] = [];
-        // token for the first line, beginning at the start char
-        tokens.push({
-            range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
-            type: token.type,
-            modifiers: token.modifiers
-        });
-        // tokens for intermediate lines, spanning from 0 to maxLineLength
-        for (let i = 1; i < lineDiff; i++) {
-            const middleToken: Token = {
-                range: new vscode.Range(
-                    new vscode.Position(start.line + i, 0),
-                    new vscode.Position(start.line + i, maxLineLength)),
-                type: token.type,
-                modifiers: token.modifiers,
-            };
-            tokens.push(middleToken);
-        }
-        // token for the last line, ending at the end char
-        tokens.push({
-            range: new vscode.Range(new vscode.Position(end.line, 0), end),
-            type: token.type,
-            modifiers: token.modifiers
-        });
-        return tokens;
-    } else {
-        return [token];
-    }
+	const start = token.range.start;
+	const end = token.range.end;
+	if (start.line != end.line) {
+		// 100_0000 is chosen as the arbitrary length, since the actual line length is unknown.
+		// Choosing a big number works, while `Number.MAX_VALUE` seems to confuse VSCode.
+		const maxLineLength = 100_000;
+		const lineDiff = end.line - start.line;
+		if (lineDiff < 0) {
+			throw new RangeError("Invalid token range");
+		}
+		let tokens: Token[] = [];
+		// token for the first line, beginning at the start char
+		tokens.push({
+			range: new vscode.Range(start, new vscode.Position(start.line, maxLineLength)),
+			type: token.type,
+			modifiers: token.modifiers
+		});
+		// tokens for intermediate lines, spanning from 0 to maxLineLength
+		for (let i = 1; i < lineDiff; i++) {
+			const middleToken: Token = {
+				range: new vscode.Range(
+					new vscode.Position(start.line + i, 0),
+					new vscode.Position(start.line + i, maxLineLength)),
+				type: token.type,
+				modifiers: token.modifiers,
+			};
+			tokens.push(middleToken);
+		}
+		// token for the last line, ending at the end char
+		tokens.push({
+			range: new vscode.Range(new vscode.Position(end.line, 0), end),
+			type: token.type,
+			modifiers: token.modifiers
+		});
+		return tokens;
+	} else {
+		return [token];
+	}
 }
 
 class SemanticTokensProvider implements vscode.DocumentSemanticTokensProvider {
-    private readonly configs: Config[];
-    private tsLangs: { [lang: string]: Language } = {};
-    private currentLanguage: string = "";
-    private readonly configs: Config[];
-    private tsLangs: { [lang: string]: Language } = {};
-    private currentLanguage: string = "";
+	private readonly configs: Config[];
+	private tsLangs: { [lang: string]: Language } = {};
+	private currentLanguage: string = "";
+	private readonly configs: Config[];
+	private tsLangs: { [lang: string]: Language } = {};
+	private currentLanguage: string = "";
 
-    constructor(configs: Config[]) {
-        this.configs = configs;
-    }
-    constructor(configs: Config[]) {
-        this.configs = configs;
-    }
+	constructor(configs: Config[]) {
+		this.configs = configs;
+	}
+	constructor(configs: Config[]) {
+		this.configs = configs;
+	}
 
-    /**
-     * Called regularly by VSCode to provide semantic tokens for the given document.
-     * It parses the document with the corresponding language parser and returns the tokens.
-     */
-    async provideDocumentSemanticTokens(
-        document: vscode.TextDocument,
-        token: vscode.CancellationToken
-    ) {
-        const lang = document.languageId;
-        this.currentLanguage = lang;
-        if (!(lang in this.tsLangs)) {
-            const config = this.configs.find(config => config.lang === lang);
-            if (config === undefined) {
-                throw new Error("No config for lang provided.");
-            }
-            this.tsLangs[lang] = await initLanguage(config);
-        }
-        const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
-        const builder = new vscode.SemanticTokensBuilder(LEGEND);
-        tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
-        return builder.build();
-    }
+	/**
+	 * Called regularly by VSCode to provide semantic tokens for the given document.
+	 * It parses the document with the corresponding language parser and returns the tokens.
+	 */
+	async provideDocumentSemanticTokens(
+		document: vscode.TextDocument,
+		token: vscode.CancellationToken
+	) {
+		const lang = document.languageId;
+		this.currentLanguage = lang;
+		if (!(lang in this.tsLangs)) {
+			const config = this.configs.find(config => config.lang === lang);
+			if (config === undefined) {
+				throw new Error("No config for lang provided.");
+			}
+			this.tsLangs[lang] = await initLanguage(config);
+		}
+		const tokens = await this.parseToTokens(this.tsLangs[lang], document.getText(), { row: 0, column: 0 });
+		const builder = new vscode.SemanticTokensBuilder(LEGEND);
+		tokens.forEach(token => builder.push(token.range, token.type, token.modifiers));
+		return builder.build();
+	}
 
-    /**
-     * Parses the given text with the given language parser and returns the highlighting tokens.
-     * Calls `getInjections` for nested injections.
-     */
-    async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
-        const { parser, highlightQuery, injectionQuery } = lang;
-        const tree = parser.parse(text);
-        const matches = highlightQuery.matches(tree.rootNode);
-        let tokens = this.matchesToTokens(matches);
-        if (injectionQuery !== undefined) {
-            const injections = await this.getInjections(injectionQuery, tree.rootNode);
-            // merge the injection tokens with the main tokens
-            for (const injection of injections) {
-                if (injection.tokens.length > 0) {
-                    const range = injection.range;
-                    tokens = tokens
-                        // remove all tokens that are contained in an injection
-                        .filter(token => !range.contains(token.range))
-                        // split tokens that are partially contained in an injection
-                        .flatMap(token => {
-                            if (token.range.intersection(range) !== undefined) {
-                                let newTokens: Token[] = [];
-                                if (token.range.start.isBefore(range.start)) {
-                                    const before = new vscode.Range(token.range.start, range.start);
-                                    newTokens.push({ ...token, range: before });
-                                }
-                                if (token.range.end.isAfter(range.end)) {
-                                    const after = new vscode.Range(range.end, token.range.end);
-                                    newTokens.push({ ...token, range: after });
-                                }
-                                return newTokens;
-                            } else {
-                                return [token];
-                            }
-                        });
-                }
-            }
-            tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
-        }
-        tokens = tokens
-            .map(token => {
-                return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
-            });
-        return tokens;
-    }
+	/**
+	 * Parses the given text with the given language parser and returns the highlighting tokens.
+	 * Calls `getInjections` for nested injections.
+	 */
+	async parseToTokens(lang: Language, text: string, startPosition: Parser.Point): Promise<Token[]> {
+		const { parser, highlightQuery, injectionQuery } = lang;
+		const tree = parser.parse(text);
+		const matches = highlightQuery.matches(tree.rootNode);
+		let tokens = this.matchesToTokens(matches);
+		if (injectionQuery !== undefined) {
+			const injections = await this.getInjections(injectionQuery, tree.rootNode);
+			// merge the injection tokens with the main tokens
+			for (const injection of injections) {
+				if (injection.tokens.length > 0) {
+					const range = injection.range;
+					tokens = tokens
+						// remove all tokens that are contained in an injection
+						.filter(token => !range.contains(token.range))
+						// split tokens that are partially contained in an injection
+						.flatMap(token => {
+							if (token.range.intersection(range) !== undefined) {
+								let newTokens: Token[] = [];
+								if (token.range.start.isBefore(range.start)) {
+									const before = new vscode.Range(token.range.start, range.start);
+									newTokens.push({ ...token, range: before });
+								}
+								if (token.range.end.isAfter(range.end)) {
+									const after = new vscode.Range(range.end, token.range.end);
+									newTokens.push({ ...token, range: after });
+								}
+								return newTokens;
+							} else {
+								return [token];
+							}
+						});
+				}
+			}
+			tokens = tokens.concat(injections.map(injection => injection.tokens).flat());
+		}
+		tokens = tokens
+			.map(token => {
+				return { ...token, range: addPosition(token.range, convertPosition(startPosition)) }
+			});
+		return tokens;
+	}
 
-    matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
-        const unsplitTokens: Token[] = matches
-            .flatMap(match => match.captures)
-            .flatMap(capture => {
-                // Store the original capture name before splitting
-                const originalCaptureName = capture.name;
-                let { type, modifiers: modifiers } = parseCaptureName(capture.name);
-                let start = convertPosition(capture.node.startPosition);
-                let end = convertPosition(capture.node.endPosition);
+	matchesToTokens(matches: Parser.QueryMatch[]): Token[] {
+		const unsplitTokens: Token[] = matches
+			.flatMap(match => match.captures)
+			.flatMap(capture => {
+				// Store the original capture name before splitting
+				const originalCaptureName = capture.name;
+				let { type, modifiers: modifiers } = parseCaptureName(capture.name);
+				let start = convertPosition(capture.node.startPosition);
+				let end = convertPosition(capture.node.endPosition);
 
-                // Apply token type mappings, first checking the full capture name
-                const lang = this.tsLangs[this.currentLanguage];
+				// Apply token type mappings, first checking the full capture name
+				const lang = this.tsLangs[this.currentLanguage];
 
-                // First check if we have a mapping for the original unsplit name
-                if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, originalCaptureName)) {
-                    const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
+				// First check if we have a mapping for the original unsplit name
+				if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, originalCaptureName)) {
+					const mapping = lang.semanticTokenTypeMappings[originalCaptureName];
 
-                    type = mapping.targetTokenType;
-                    if (mapping.targetTokenModifiers) {
-                        modifiers = mapping.targetTokenModifiers;
-                    }
-                }
-                // If no mapping for the full name, check for just the type
-                else if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, type)) {
-                    const mapping = lang.semanticTokenTypeMappings[type];
+					type = mapping.targetTokenType;
+					if (mapping.targetTokenModifiers) {
+						modifiers = mapping.targetTokenModifiers;
+					}
+				}
+				// If no mapping for the full name, check for just the type
+				else if (lang?.semanticTokenTypeMappings && Object.prototype.hasOwnProperty.call(lang.semanticTokenTypeMappings, type)) {
+					const mapping = lang.semanticTokenTypeMappings[type];
 
-                    type = mapping.targetTokenType;
-                    if (mapping.targetTokenModifiers) {
-                        modifiers = mapping.targetTokenModifiers;
-                    }
-                }
+					type = mapping.targetTokenType;
+					if (mapping.targetTokenModifiers) {
+						modifiers = mapping.targetTokenModifiers;
+					}
+				}
 
-                if (TOKEN_TYPES.includes(type)) {
-                    const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
-                    const token: Token = {
-                        range: new vscode.Range(start, end),
-                        type: type,
-                        modifiers: validModifiers
-                    };
-                    return token;
-                } else {
-                    return [];
-                }
-            });
+				if (TOKEN_TYPES.includes(type)) {
+					const validModifiers = modifiers.filter(modifier => TOKEN_MODIFIERS.includes(modifier));
+					const token: Token = {
+						range: new vscode.Range(start, end),
+						type: type,
+						modifiers: validModifiers
+					};
+					return token;
+				} else {
+					return [];
+				}
+			});
 
-        return unsplitTokens.flatMap(token => {
-            // Get all tokens contained within this token
-            const contained = unsplitTokens.filter(t =>
-                (!(token.range.isEqual(t.range))) && token.range.contains(t.range)
-            );
+		return unsplitTokens.flatMap(token => {
+			// Get all tokens contained within this token
+			const contained = unsplitTokens.filter(t =>
+				(!(token.range.isEqual(t.range))) && token.range.contains(t.range)
+			);
 
-            if (contained.length > 0) {
-                // Sort contained tokens by their start position
-                const sortedContained = contained.sort((a, b) =>
-                    a.range.start.compareTo(b.range.start)
-                );
+			if (contained.length > 0) {
+				// Sort contained tokens by their start position
+				const sortedContained = contained.sort((a, b) =>
+					a.range.start.compareTo(b.range.start)
+				);
 
-                let resultTokens = [];
-                let currentPos = token.range.start;
+				let resultTokens = [];
+				let currentPos = token.range.start;
 
-                // Create tokens for the gaps between contained tokens
-                for (const containedToken of sortedContained) {
-                    // If there's a gap before this contained token, create a token for it
-                    if (currentPos.compareTo(containedToken.range.start) < 0) {
-                        resultTokens.push({
-                            ...token,
-                            range: new vscode.Range(currentPos, containedToken.range.start),
-                        });
-                    }
-                    currentPos = containedToken.range.end;
-                }
+				// Create tokens for the gaps between contained tokens
+				for (const containedToken of sortedContained) {
+					// If there's a gap before this contained token, create a token for it
+					if (currentPos.compareTo(containedToken.range.start) < 0) {
+						resultTokens.push({
+							...token,
+							range: new vscode.Range(currentPos, containedToken.range.start),
+						});
+					}
+					currentPos = containedToken.range.end;
+				}
 
-                // Add token for the gap after the last contained token if needed
-                if (currentPos.compareTo(token.range.end) < 0) {
-                    resultTokens.push({
-                        ...token,
-                        range: new vscode.Range(currentPos, token.range.end),
-                    });
-                }
+				// Add token for the gap after the last contained token if needed
+				if (currentPos.compareTo(token.range.end) < 0) {
+					resultTokens.push({
+						...token,
+						range: new vscode.Range(currentPos, token.range.end),
+					});
+				}
 
-                return resultTokens;
-            } else {
-                return token;
-            }
-        }).flatMap(splitToken);
-    }
+				return resultTokens;
+			} else {
+				return token;
+			}
+		}).flatMap(splitToken);
+	}
 
-    /**
-     * Get the injection range and tokens for a specific match.
-     */
-    async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
-        // determine language
-        const {
-            "injection.language": injectionLanguage,
-            // TODO: add support for self and parent injections
-            // "injection.self": injectionSelf,
-            // "injection.parent": injectionParent
-        } = (match as any).setProperties || {};
-        // the language is hard coded by "set!"
-        const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
-        // dynamically determined language
-        const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
-        // custom language determination by capture name
-        const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
+	/**
+	 * Get the injection range and tokens for a specific match.
+	 */
+	async getInjection(match: Parser.QueryMatch): Promise<Injection | null> {
+		// determine language
+		const {
+			"injection.language": injectionLanguage,
+			// TODO: add support for self and parent injections
+			// "injection.self": injectionSelf,
+			// "injection.parent": injectionParent
+		} = (match as any).setProperties || {};
+		// the language is hard coded by "set!"
+		const hardCoded = typeof injectionLanguage == "string" ? injectionLanguage : undefined;
+		// dynamically determined language
+		const dynamic = match.captures.find(capture => capture.name === "injection.language")?.node.text;
+		// custom language determination by capture name
+		const name = match.captures.find(capture => this.configs.map(config => config.lang).includes(capture.name))?.name;
 
-        const lang = hardCoded || dynamic || name;
-        if (lang === undefined) return null;
-        const lang = hardCoded || dynamic || name;
-        if (lang === undefined) return null;
+		const lang = hardCoded || dynamic || name;
+		if (lang === undefined) return null;
+		const lang = hardCoded || dynamic || name;
+		if (lang === undefined) return null;
 
-        // determine capture
-        let capture = undefined;
-        if (hardCoded !== undefined) {
-            if (match.captures.length === 0) return null;
-            // use first capture (there should only be one)
-            capture = match.captures[0];
-        } else if (dynamic !== undefined) {
-            capture = match.captures.find(capture => capture.name === "injection.content");
-        } else if (name !== undefined) {
-            capture = match.captures.find(capture => capture.name === name);
-        }
-        if (capture === undefined) return null;
+		// determine capture
+		let capture = undefined;
+		if (hardCoded !== undefined) {
+			if (match.captures.length === 0) return null;
+			// use first capture (there should only be one)
+			capture = match.captures[0];
+		} else if (dynamic !== undefined) {
+			capture = match.captures.find(capture => capture.name === "injection.content");
+		} else if (name !== undefined) {
+			capture = match.captures.find(capture => capture.name === name);
+		}
+		if (capture === undefined) return null;
 
-        // get language config
-        const config = this.configs.find(config => config.lang === lang);
-        if (config === undefined) return null;
+		// get language config
+		const config = this.configs.find(config => config.lang === lang);
+		if (config === undefined) return null;
 
-        if (!(lang in this.tsLangs)) {
-            this.tsLangs[lang] = await initLanguage(config);
-        }
-        const langConfig = this.tsLangs[lang];
-        if (!(lang in this.tsLangs)) {
-            this.tsLangs[lang] = await initLanguage(config);
-        }
-        const langConfig = this.tsLangs[lang];
+		if (!(lang in this.tsLangs)) {
+			this.tsLangs[lang] = await initLanguage(config);
+		}
+		const langConfig = this.tsLangs[lang];
+		if (!(lang in this.tsLangs)) {
+			this.tsLangs[lang] = await initLanguage(config);
+		}
+		const langConfig = this.tsLangs[lang];
 
-        let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
-        let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
-        return { range, tokens };
-    }
+		let tokens = await this.parseToTokens(langConfig, capture.node.text, capture.node.startPosition);
+		let range = new vscode.Range(convertPosition(capture.node.startPosition), convertPosition(capture.node.endPosition));
+		return { range, tokens };
+	}
 
-    /**
-     * Matches the given injection query against the given node and returns the highlighting tokens.
-     * This also works for nested injections.
-     */
-    async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
-        const matches = injectionQuery.matches(node);
-        const injections = matches.map(async match => await this.getInjection(match));
-        return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
-    }
+	/**
+	 * Matches the given injection query against the given node and returns the highlighting tokens.
+	 * This also works for nested injections.
+	 */
+	async getInjections(injectionQuery: Parser.Query, node: Parser.SyntaxNode): Promise<Injection[]> {
+		const matches = injectionQuery.matches(node);
+		const injections = matches.map(async match => await this.getInjection(match));
+		return (await Promise.all(injections)).filter((injection): injection is Injection => injection !== null);
+	}
 }


### PR DESCRIPTION
This PR introduces a new configuration setting that allows users to specify how Tree-sitter semantic token types are mapped to VSCode semantic token types. This feature addresses issue [#9](https://github.com/AlecGhost/tree-sitter-vscode/issues/9) and enables users to leverage the excellent highlights files available from `nvim-treesitter`—with minor overrides—to achieve identical syntax highlighting in VSCode as seen in Neovim.

**Key Changes:**

1. New Configuration Option `semanticTokenTypeMappings`:

- Users can now customize how Tree-sitter token types translate to VSCode semantic token types.
- Example configuration in settings.json:
  
```json
  "tree-sitter-vscode.languageConfigs": [
    {
      "highlights": "/Users/sherif/.local/share/nvim/lazy/nvim-treesitter/queries/go/highlights.scm",
      "lang": "go",
      "parser": "/Users/sherif/.local/share/tree-sitter/go/tree-sitter-go.wasm",
      "semanticTokenTypeMappings": {
        "constant": {
          "targetTokenType": "variable",
          "targetTokenModifiers": ["declaration", "readonly"]
        },
        "module": {
          "targetTokenType": "namespace"
        },
        "variable.member": {
          "targetTokenType": "property"
        },
        "variable.parameter": {
          "targetTokenType": "parameter"
        }
      }
    }
  ]
```

  In this configuration, a Tree-sitter token type `constant` is converted to a VSCode token type `variable` with the modifiers `declaration` and `readonly`.

2. Debugging Enhancements:

- Added a debugging feature that writes log messages to the “Tree Sitter” VSCode output channel.
-  Enable debugging by setting:
  
```json
"tree-sitter-vscode.debug": true
```

3. Code Formatting:

- The PR also includes code formatting improvements using Prettier, ensuring consistent and clean code style across the project