### PR TITLE
Add semantic token type mapping functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Supported Tree-sitter ABI version: 14
 ### Features
 
 - Add support for relative paths
+- Add support to configure how Tree-sitter semantic token types are mapped to VS Code semantic token types
 
 ## 0.1.0
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ and the location of the query files on the file system in the `settings.json`.
 For each language that you want to parse,
 a dictionary with the following keys needs to be added.
 
-| Key           | Description                                                                                                                   |
-| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| lang          | The language identifier                                                                                                       |
-| parser        | The path to your parser's WASM file                                                                                           |
-| highlights    | The path to the file with your highlighting queries.                                                                          |
-| injections    | The path to the file with your injection queries. (optional)                                                                  |
-| injectionOnly | Whether this language should only be highlighted in injections, and not in files of that file type. (optional, default=false) |
+| Key                       | Description                                                                                                                   |
+| -------------             | ----------------------------------------------------------------------------------------------------------------------------- |
+| lang                      | The language identifier                                                                                                       |
+| parser                    | The path to your parser's WASM file                                                                                           |
+| highlights                | The path to the file with your highlighting queries.                                                                          |
+| injections                | The path to the file with your injection queries. (optional)                                                                  |
+| injectionOnly             | Whether this language should only be highlighted in injections, and not in files of that file type. (optional, default=false) |
+| semanticTokenTypeMappings | Object of rules specifying how Tree-sitter semantic token types are mapped to VS Code semantic token types                    |
 
 Note, that this extension uses the WASM bindings for the Tree-sitter parsers.
 Have a look 
@@ -53,7 +54,22 @@ to see how you can generate those.
         "lang": "xyz",
         "parser": "/path/to/your/tree-sitter-xyz.wasm",
         "highlights": "/path/to/your/highlights.scm",
-        "injections": "/path/to/your/injections.scm"
+        "injections": "/path/to/your/injections.scm",
+        "semanticTokenTypeMappings": {
+            "constant": {
+                "targetTokenModifiers": ["declaration", "readonly"],
+                "targetTokenType": "variable"
+            },
+            "module": {
+                "targetTokenType": "namespace"
+            },
+            "variable.member": {
+                "targetTokenType": "property"
+            },
+            "variable.parameter": {
+                "targetTokenType": "parameter"
+            }
+      }
     }
 ]
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tree-sitter-vscode",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tree-sitter-vscode",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@vscode/vsce": "^2.24.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AlecGhost"
   },
   "publisher": "AlecGhost",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/AlecGhost/tree-sitter-vscode"
@@ -28,7 +28,7 @@
         "title": "tree-sitter-vscode config",
         "properties": {
           "tree-sitter-vscode.languageConfigs": {
-            "description": "A list of objects with the keys \"lang\", \"parser\" and \"highlights\". Optionally, \"injections\" and \"injectionOnly\" can be added.",
+            "description": "A list of objects with the keys \"lang\", \"parser\", and \"highlights\". Optionally \"injections\", \"injectionOnly\", and \"semanticTokenTypeMappings\" can be added.",
             "type": "array",
             "default": []
           }


### PR DESCRIPTION
This PR introduces a new configuration setting that allows users to specify how Tree-sitter semantic token types are mapped to VS Code semantic token types. This feature addresses issue https://github.com/AlecGhost/tree-sitter-vscode/issues/9 and enables users to leverage the excellent highlights files available from `nvim-treesitter`—with minor overrides—to achieve identical syntax highlighting in VSCode as seen in Neovim.

**Key Changes:**

Add a new configuration option `semanticTokenTypeMappings` allowing users to customize how Tree-sitter token types translate to VS Code semantic token types

Example configuration in `settings.json`
  
```json
"tree-sitter-vscode.languageConfigs": [
    {
      "highlights": "/Users/sherif/.local/share/nvim/lazy/nvim-treesitter/queries/go/highlights.scm",
      "lang": "go",
      "parser": "/Users/sherif/.local/share/tree-sitter/go/tree-sitter-go.wasm",
      "semanticTokenTypeMappings": {
        "constant": {
          "targetTokenType": "variable",
          "targetTokenModifiers": ["declaration", "readonly"]
        },
        "module": {
          "targetTokenType": "namespace"
        },
        "variable.member": {
          "targetTokenType": "property"
        },
        "variable.parameter": {
          "targetTokenType": "parameter"
        }
      }
    }
  ]
```

In this configuration, a Tree-sitter token type constant is converted to a VSCode token type variable with the modifiers declaration and readonly.