### PR TITLE
Add output channel to log debug messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## 0.2.1
+
+Supported Tree-sitter ABI version: 14
+
+### Features
+
+- Add output channel to log debug messages if the "tree-sitter-vscode.debug" configuration setting is set to `true`
+
 ## 0.2.0
 
 Supported Tree-sitter ABI version: 14

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AlecGhost"
   },
   "publisher": "AlecGhost",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "repository": {
     "url": "https://github.com/AlecGhost/tree-sitter-vscode"
@@ -31,6 +31,11 @@
             "description": "A list of objects with the keys \"lang\", \"parser\", and \"highlights\". Optionally \"injections\", \"injectionOnly\", and \"semanticTokenTypeMappings\" can be added.",
             "type": "array",
             "default": []
+          },
+          "tree-sitter-vscode.debug": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable debug logging"
           }
         }
       }


### PR DESCRIPTION
This PR adds functionality to create a VS Code output channel called `tree-sitter-vscode` for the extension to log debug messages.

Debug messages are enabled using the configuration settings

```json
"tree-sitter-vscode.debug": true
```