### PR TITLE
Mention ABI WASM version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ a dictionary with the following keys needs to be added.
 | injectionOnly             | Whether this language should only be highlighted in injections, and not in files of that file type. (optional, default=false) |
 | semanticTokenTypeMappings | Object of rules specifying how Tree-sitter semantic token types are mapped to VS Code semantic token types                    |
 
-Note, that this extension uses the WASM bindings for the Tree-sitter parsers.
-Have a look 
-[here](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md#generate-wasm-language-files)
+Note, that this extension uses the WASM bindings for the Tree-sitter parsers. Make sure they are generated with ABI version 13 or 14 !
+
+You can generate them with the following commands, if you have the latest tree-sitter CLI
+```sh
+tree-sitter generate --abi 14
+tree-sitter build --wasm
+```
+
+Otherwise have a look
+[here](https://github.com/tree-sitter/tree-sitter/blob/master/lib/binding_web/README.md#getting-the-wasm-language-files)
 to see how you can generate those.
 
 ```json


### PR DESCRIPTION
Hello,

Thanks for this extension, @AlecGhost, that's nice to see I can integrate my new custom syntax in VSCode, in waiting the official Tree-Sitter support of VSCode. I was in the same situation as @mietschie in issue #7.

> My issue was that my parser was compiled for ABI version 15 but the extension expects 13 or 14. The solution was building the parser with an older tree-sitter build.

There is an easier fix if you have the latest version, you can change the ABI version with `--abi 14`. The latest version doesn't support version 13, but it supports the 14th.

This PR brings this mention in the README to help future people. It also fixes the anchor `#getting-the-wasm-language-files` with the missing `the` in the link.